### PR TITLE
Update status chips to use Vuetify colors

### DIFF
--- a/src/views/PanelSeguimientos/GuidesTable.vue
+++ b/src/views/PanelSeguimientos/GuidesTable.vue
@@ -83,7 +83,7 @@
           <span class="body-2">{{ item.FechaOriginal }}</span>
         </template>
         <template v-slot:item.Estado="{ item }">
-          <v-chip :class="statusChipClassFn(item.Estado)" small>
+          <v-chip :color="statusChipClassFn(item.Estado)" dark small>
             {{ item.Estado }}
           </v-chip>
         </template>

--- a/src/views/PanelSeguimientos/OrdersTable.vue
+++ b/src/views/PanelSeguimientos/OrdersTable.vue
@@ -80,7 +80,7 @@
           <span class="body-2">{{ item.Creada }}</span>
         </template>
         <template v-slot:item.estadoActual="{ item }">
-          <v-chip :class="statusChipClassFn(item.Estado)" small>
+          <v-chip :color="statusChipClassFn(item.Estado)" dark small>
             {{ item.Estado }}
           </v-chip>
         </template>

--- a/src/views/PanelSeguimientos/SeguimientoModal.vue
+++ b/src/views/PanelSeguimientos/SeguimientoModal.vue
@@ -126,7 +126,7 @@
                       Estado Actual:
                     </v-list-item-title>
                     <v-list-item-subtitle>
-                      <v-chip :class="statusChipClassFn(modalData.NombreEstado || modalData.Estado)" small>
+                      <v-chip :color="statusChipClassFn(modalData.NombreEstado || modalData.Estado)" dark small>
                         {{ modalData.NombreEstado || modalData.Estado }}
                       </v-chip>
                     </v-list-item-subtitle>

--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -1301,40 +1301,41 @@ export default {
      * @returns {string} Clases CSS de Vuetify.
      */
     getStatusChipClassTextual(estado) {
-      // Clases para estados de Órdenes.
-      if (['Pendiente', 'Preparado', 'A distribuciòn', 'Anulado', 'Retira Cliente'].includes(estado)) {
-        switch (estado) {
-          case 'Pendiente': return 'grey lighten-4 amber--text text--darken-3'; // Amarillo para advertencia.
-          case 'Preparado': return 'grey lighten-4 blue--text text--darken-2'; // Azul para información.
-          case 'A distribuciòn': return 'grey lighten-4 green--text text--darken-2'; // Verde para éxito/distribución.
-          case 'Anulado': return 'grey lighten-4 red--text text--darken-2'; // Rojo para error/anulado.
-          case 'Retira Cliente': return 'grey lighten-4 deep-purple--text text--darken-2'; // Morado para retiro.
-          default: return 'grey lighten-4 grey--text text--darken-1'; // Gris por defecto.
-        }
+      // Colores para estados de Órdenes.
+      const mapOrdenes = {
+        'Pendiente': 'warning',
+        'Preparado': 'info',
+        'A distribuciòn': 'success',
+        'Anulado': 'error',
+        'Retira Cliente': 'info'
       }
-      // Clases para estados de Guías (basadas en `VistaDeTracking.vue`).
-      else if (['Pedido en preparación', 'Pedido preparado', 'En CD', 'En Planchada', 'Ruteado', 'DESPACHADO', 'En distribución', 'Entregado', 'No entregado', 'Entrega parcial', 'Pedido retirado', 'ANULADO'].includes(estado)) {
-          switch (estado) {
-              case 'Entregado':
-              case 'Pedido preparado':
-              case 'Pedido en preparación':
-              case 'En CD':
-              case 'En Planchada':
-              case 'Ruteado':
-              case 'DESPACHADO':
-              case 'En distribución':
-              case 'Pedido retirado':
-                  return 'grey lighten-4 green--text text--darken-2'; // Verde para estados de progreso positivo.
-              case 'No entregado':
-              case 'ANULADO': // Añadido para guías anuladas
-                  return 'grey lighten-4 red--text text--darken-2'; // Rojo para no entregado o anulado.
-              case 'Entrega parcial':
-                  return 'grey lighten-4 orange--text text--darken-2'; // Naranja/Amarillo para parcial.
-              default:
-                  return 'grey lighten-4 grey--text text--darken-1'; // Gris por defecto.
-          }
+
+      if (Object.prototype.hasOwnProperty.call(mapOrdenes, estado)) {
+        return mapOrdenes[estado]
       }
-      return 'grey lighten-4 grey--text text--darken-1'; // Color por defecto si el estado no coincide.
+
+      // Colores para estados de Guías.
+      const mapGuias = {
+        'Entregado': 'success',
+        'Pedido preparado': 'success',
+        'Pedido en preparación': 'success',
+        'En CD': 'success',
+        'En Planchada': 'success',
+        'Ruteado': 'success',
+        'DESPACHADO': 'success',
+        'En distribución': 'success',
+        'Pedido retirado': 'success',
+        'No entregado': 'error',
+        'ANULADO': 'error',
+        'Entrega parcial': 'warning'
+      }
+
+      if (Object.prototype.hasOwnProperty.call(mapGuias, estado)) {
+        return mapGuias[estado]
+      }
+
+      // Color por defecto
+      return 'secondary'
     },
 
     /**


### PR DESCRIPTION
## Summary
- adjust `getStatusChipClassTextual` to return Vuetify color names
- bind chip color in orders/guides tables and modal via `color` prop

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b9d9b938832ab3ab91c4ba1aacbe