### PR TITLE
Remove N/A fallbacks in tracking pages

### DIFF
--- a/src/views/PanelSeguimientos/GuidesTable.vue
+++ b/src/views/PanelSeguimientos/GuidesTable.vue
@@ -71,13 +71,13 @@
           <span class="body-2 font-weight-bold">{{ item.Comprobante }}</span>
         </template>
         <template v-slot:item.NombreCliente="{ item }">
-          <span class="body-2">{{ item.NombreCliente || 'N/A' }}</span>
+          <span class="body-2">{{ item.NombreCliente }}</span>
         </template>
         <template v-slot:item.NombreDestino="{ item }">
-          <span class="body-2">{{ item.NombreDestino || 'N/A' }}</span>
+          <span class="body-2">{{ item.NombreDestino }}</span>
         </template>
         <template v-slot:item.Remitos="{ item }">
-          <span class="body-2">{{ item.Remitos || 'N/A' }}</span>
+          <span class="body-2">{{ item.Remitos }}</span>
         </template>
         <template v-slot:item.FechaOriginal="{ item }">
           <span class="body-2">{{ item.FechaOriginal }}</span>

--- a/src/views/PanelSeguimientos/OrdersTable.vue
+++ b/src/views/PanelSeguimientos/OrdersTable.vue
@@ -71,10 +71,10 @@
           <span class="body-2 font-weight-bold">{{ item.numero }}</span>
         </template>
         <template v-slot:item.nombreEmpresa="{ item }">
-          <span class="body-2">{{ item.nombre || 'N/A' }}</span>
+          <span class="body-2">{{ item.nombre }}</span>
         </template>
         <template v-slot:item.nombreCliente="{ item }">
-          <span class="body-2">{{ item.nombreDestino || 'N/A' }}</span>
+          <span class="body-2">{{ item.nombreDestino }}</span>
         </template>
         <template v-slot:item.fechaCreacion="{ item }">
           <span class="body-2">{{ item.Creada }}</span>

--- a/src/views/PanelSeguimientos/SeguimientoModal.vue
+++ b/src/views/PanelSeguimientos/SeguimientoModal.vue
@@ -48,7 +48,7 @@
                       Empresa:
                     </v-list-item-title>
                     <v-list-item-subtitle>
-                      {{ modalData.Empresa?.RazonSocial || modalData.NombreCliente || 'N/A' }}
+                      {{ modalData.Empresa?.RazonSocial || modalData.NombreCliente }}
                     </v-list-item-subtitle>
                   </v-list-item-content>
                 </v-list-item>
@@ -59,7 +59,7 @@
                       Cliente/Destino:
                     </v-list-item-title>
                     <v-list-item-subtitle>
-                      {{ modalData.Destino?.Nombre || modalData.NombreDestino || 'N/A' }}
+                      {{ modalData.Destino?.Nombre || modalData.NombreDestino }}
                     </v-list-item-subtitle>
                   </v-list-item-content>
                 </v-list-item>
@@ -70,7 +70,7 @@
                       Email Cliente:
                     </v-list-item-title>
                     <v-list-item-subtitle>
-                      {{ modalData.EmailDestinatario || 'N/A' }}
+                      {{ modalData.EmailDestinatario }}
                     </v-list-item-subtitle>
                   </v-list-item-content>
                 </v-list-item>
@@ -80,7 +80,7 @@
                       Remito:
                     </v-list-item-title>
                     <v-list-item-subtitle>
-                      {{ modalData.Remitos || 'N/A' }}
+                      {{ modalData.Remitos }}
                     </v-list-item-subtitle>
                   </v-list-item-content>
                 </v-list-item>
@@ -91,7 +91,7 @@
                       Fecha Creación:
                     </v-list-item-title>
                     <v-list-item-subtitle>
-                      {{ modalType === 'orden' ? (modalData.FechaCreacion ? new Date(modalData.FechaCreacion).toLocaleDateString() : 'N/A') : modalData.FechaOriginal || 'N/A' }}
+                      {{ modalType === 'orden' ? (modalData.FechaCreacion ? new Date(modalData.FechaCreacion).toLocaleDateString() : '') : modalData.FechaOriginal }}
                     </v-list-item-subtitle>
                   </v-list-item-content>
                 </v-list-item>
@@ -103,7 +103,7 @@
                     </v-list-item-title>
                     <v-list-item-subtitle>
                       <span v-if="modalData.FechaPreparado">{{ new Date(modalData.FechaPreparado).toLocaleDateString() }}</span>
-                      <span v-else>N/A</span>
+                      <span v-else></span>
                     </v-list-item-subtitle>
                   </v-list-item-content>
                 </v-list-item>
@@ -115,7 +115,7 @@
                     </v-list-item-title>
                     <v-list-item-subtitle>
                       <span v-if="modalData.Fecha">{{ new Date(modalData.Fecha).toLocaleDateString() }}</span>
-                      <span v-else>N/A</span>
+                      <span v-else></span>
                     </v-list-item-subtitle>
                   </v-list-item-content>
                 </v-list-item>

--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -729,10 +729,10 @@ export default {
 
           o.Modificada = o.Modificada
             ? new Date(o.Modificada).toLocaleDateString()
-            : 'N/A';
+            : '';
           o.Preparado = o.Preparado
             ? new Date(o.Preparado).toLocaleDateString()
-            : 'N/A';
+            : '';
 
           // Traduce el estado numérico de la orden a un estado textual legible.
           switch (o.Estado) {
@@ -749,8 +749,8 @@ export default {
           o.tipo = o.preOrden === true || o.preOrden === 1 ? 'Pre-Orden' : 'Orden';
           o.preOrdenDisplay = o.tipo;
 
-          o.nombre = o.nombre || 'N/A';
-          o.nombreDestino = o.nombreDestino || 'N/A';
+          o.nombre = o.nombre || '';
+          o.nombreDestino = o.nombreDestino || '';
           // Aseguramos que IdGuia esté presente, aunque puede ser -1 si no hay guía
           o.IdGuia = o.IdGuia || -1;
         });
@@ -796,10 +796,10 @@ export default {
         // Formatea los datos de cada guía para su visualización en la tabla.
         todas.forEach((g) => {
           g.FechaOriginalDate = new Date(g.FechaOriginal); // Crea un objeto Date para facilitar filtros y ordenamiento.
-          g.FechaOriginal = g.FechaOriginal ? new Date(g.FechaOriginal).toLocaleDateString() : 'N/A'; // Formatea la fecha original.
-          g.NombreCliente = g.NombreCliente || 'N/A';
-          g.NombreDestino = g.NombreDestino || 'N/A';
-          g.Remitos = g.Remitos || 'N/A';
+          g.FechaOriginal = g.FechaOriginal ? new Date(g.FechaOriginal).toLocaleDateString() : '';
+          g.NombreCliente = g.NombreCliente || '';
+          g.NombreDestino = g.NombreDestino || '';
+          g.Remitos = g.Remitos || '';
           g.Estado = g.Estado || 'Desconocido'; // Asegura que el estado exista y sea textual.
         });
 
@@ -844,7 +844,7 @@ export default {
               // Si se obtuvo, la agrega a la lista de guías (opcional, para futuras interacciones)
               // y abre el modal.
               // Formatea la fecha de la guía obtenida directamente para que sea consistente con la lista.
-              retrievedGuia.FechaOriginal = retrievedGuia.FechaOriginal ? new Date(retrievedGuia.FechaOriginal).toLocaleDateString() : 'N/A';
+              retrievedGuia.FechaOriginal = retrievedGuia.FechaOriginal ? new Date(retrievedGuia.FechaOriginal).toLocaleDateString() : '';
               retrievedGuia.Estado = retrievedGuia.Estado || 'Desconocido';
               this.todasLasGuias.push(retrievedGuia); // Añade la guía a la lista para que se muestre en la tabla si corresponde
               this.tab = 'tab-guias';
@@ -893,9 +893,9 @@ export default {
             // Obtiene detalles de productos y formatea fechas para el modal de orden.
             const productosDetalle = await this._obtenerDetalleProductos(dataToModal);
             dataToModal.productosDetalle = productosDetalle;
-            dataToModal.Creada = dataToModal.FechaCreacion ? new Date(dataToModal.FechaCreacion).toLocaleDateString() : 'N/A';
-            dataToModal.Preparado = dataToModal.FechaPreparado ? new Date(dataToModal.FechaPreparado).toLocaleDateString() : 'N/A';
-            dataToModal.FechaDistribucion = dataToModal.Fecha ? new Date(dataToModal.Fecha).toLocaleDateString() : 'N/A';
+            dataToModal.Creada = dataToModal.FechaCreacion ? new Date(dataToModal.FechaCreacion).toLocaleDateString() : '';
+            dataToModal.Preparado = dataToModal.FechaPreparado ? new Date(dataToModal.FechaPreparado).toLocaleDateString() : '';
+            dataToModal.FechaDistribucion = dataToModal.Fecha ? new Date(dataToModal.Fecha).toLocaleDateString() : '';
             // Asegura que el estado textual para el modal se use correctamente.
             switch (dataToModal.Estado) {
               case 1: dataToModal.NombreEstado = 'Pendiente'; break;
@@ -905,7 +905,7 @@ export default {
               case 5: dataToModal.NombreEstado = 'Retira Cliente'; break;
               default: dataToModal.NombreEstado = `Desconocido (${dataToModal.Estado})`;
             }
-            dataToModal.nombreCliente = dataToModal.Destino?.Nombre || 'N/A';
+            dataToModal.nombreCliente = dataToModal.Destino?.Nombre || '';
             console.log("openModal: Datos de orden para modal procesados:", dataToModal);
           } else {
             // Lanza un error si el objeto de la orden no es válido.
@@ -919,12 +919,12 @@ export default {
           dataToModal.productosDetalle = []; // Por ahora, se inicializa vacío.
 
           // Formatea fechas específicas de la guía para el modal.
-          dataToModal.FechaOriginal = dataToModal.FechaOriginal ? new Date(dataToModal.FechaOriginal).toLocaleDateString() : 'N/A';
+          dataToModal.FechaOriginal = dataToModal.FechaOriginal ? new Date(dataToModal.FechaOriginal).toLocaleDateString() : '';
           // Para la fecha de no entrega, se usa la `Fecha` de la guía si el estado es `NO ENTREGADO`.
           if (dataToModal.Estado === 'NO ENTREGADO' && dataToModal.Fecha) {
               dataToModal.FechaNoEntregado = new Date(dataToModal.Fecha).toLocaleDateString();
           } else {
-            dataToModal.FechaNoEntregado = 'N/A';
+            dataToModal.FechaNoEntregado = '';
           }
            console.log("openModal: Datos de guía para modal procesados:", dataToModal);
         }
@@ -994,10 +994,10 @@ export default {
       const isRetiraCliente = currentStatusText === 'Retira Cliente'; // Usa el estado textual para la verificación.
 
       // Fechas ya formateadas en el `openModal`.
-      const fechaModificada = orden.Modificada || 'N/A';
-      const fechaCreacion = orden.Creada || 'N/A';
-      const fechaPreparado = orden.Preparado || 'N/A';
-      const fechaDistribucion = orden.FechaDistribucion || 'N/A';
+      const fechaModificada = orden.Modificada || '';
+      const fechaCreacion = orden.Creada || '';
+      const fechaPreparado = orden.Preparado || '';
+      const fechaDistribucion = orden.FechaDistribucion || '';
 
       if (isAnulada) {
         // Si la orden está anulada, solo se muestra el paso de anulación con estado 'current-bad'.
@@ -1006,7 +1006,7 @@ export default {
           nombre: 'Orden Anulada',
           icon: 'mdi-cancel',
           fecha: fechaModificada,
-          descripcion: `La orden ha sido cancelada por ${orden.Usuario || 'N/A'}.`,
+          descripcion: `La orden ha sido cancelada por ${orden.Usuario || ''}.`,
           statusClass: 'current-bad', // Clase para estados negativos actuales.
         });
       } else {
@@ -1030,7 +1030,7 @@ export default {
           nombre: 'Pendiente',
           icon: 'mdi-file-document-edit-outline',
           fecha: fechaCreacion,
-          descripcion: `Ingresada por: ${orden.UsuarioCreoOrd || 'N/A'}.`,
+          descripcion: `Ingresada por: ${orden.UsuarioCreoOrd || ''}.`,
           statusClass:
             currentStatusText === 'Pendiente'
               ? 'current' // Es el estado actual
@@ -1120,8 +1120,8 @@ export default {
       const isRetiraClienteSucursal = guia.Domicilio && guia.Domicilio.toLowerCase().includes("lagos garcia 4470");
 
       // Fechas ya formateadas en el `openModal`.
-      const fechaOriginal = guia.FechaOriginal || 'N/A';
-      const fechaNoEntregado = guia.FechaNoEntregado || 'N/A'; // Fecha específica para estado "No entregado".
+      const fechaOriginal = guia.FechaOriginal || '';
+      const fechaNoEntregado = guia.FechaNoEntregado || ''; // Fecha específica para estado "No entregado".
 
       // Pasos base de la línea de tiempo con un `baseOrder` para facilitar la lógica de avance.
       const baseSteps = [
@@ -1153,8 +1153,8 @@ export default {
           id: 'en_distribucion',
           nombre: 'En distribución',
           icon: 'mdi-truck-fast-outline',
-          // La fecha de distribución podría ser la fecha original si está despachado, o "N/A".
-          fecha: guia.Estado === 'DESPACHADO' ? fechaOriginal : 'N/A', // Usamos la fecha original si está despachado, o "N/A"
+          // La fecha de distribución podría ser la fecha original si está despachado, o vacía.
+          fecha: guia.Estado === 'DESPACHADO' ? fechaOriginal : '',
           descripcion: '¡Tu pedido ya está en camino!',
           baseOrder: 4,
         },
@@ -1189,7 +1189,7 @@ export default {
           id: 'retirado',
           nombre: 'Pedido retirado',
           icon: 'mdi-kabaddi',
-          fecha: currentStatusText === 'ENTREGADO' ? fechaOriginal : 'N/A', // Asume fecha original si fue entregado.
+          fecha: currentStatusText === 'ENTREGADO' ? fechaOriginal : '',
           descripcion: `El pedido fue retirado de nuestro centro de distribución.`,
           // El estado es 'current' si la guía está 'ENTREGADO', sino 'pending'.
           statusClass: currentStatusText === 'ENTREGADO' ? 'current' : 'pending'


### PR DESCRIPTION
## Summary
- display empty values when fields are missing in orders/guides tables
- simplify modal field handling by removing redundant `'N/A'` strings
- clean up helpers in Seguimientos.vue to avoid default `'N/A'`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847bea96018832a971dd5c36b8f8504