### PR TITLE
Set DM Sans as global font

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -1,0 +1,8 @@
+html, body {
+  font-family: 'DM Sans', sans-serif;
+}
+
+/* Ensure Vuetify components also inherit the font */
+* {
+  font-family: inherit;
+}

--- a/src/components/LoginGoogle.vue
+++ b/src/components/LoginGoogle.vue
@@ -129,7 +129,7 @@ export default {
 
 .btn-text {
   color: #3c4043;
-  font-family: 'Google Sans', 'Roboto', sans-serif;
+  font-family: 'DM Sans', sans-serif;
   font-size: 14px;
   font-weight: 500;
   letter-spacing: 0.25px;

--- a/src/components/MenuPrincipal.vue
+++ b/src/components/MenuPrincipal.vue
@@ -496,7 +496,7 @@ export default {
 /* Fuente y compactado en los dropdowns */
 .v-toolbar__content {
   font-size: 13px !important;
-  font-family: "Segoe UI", Arial, sans-serif;
+  font-family: 'DM Sans', sans-serif;
   letter-spacing: 0;
   line-height: 1.1;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import router from './router'
 import store from './store'
 import vuetify from './plugins/vuetify'
 import axios from 'axios'
+import './assets/global.css'
 // import VueConfirmDialog from 'vue-confirm-dialog'
 
 // Vue.use(VueConfirmDialog)

--- a/src/views/Ordenes/PrepararOrden.vue
+++ b/src/views/Ordenes/PrepararOrden.vue
@@ -138,7 +138,7 @@ export default {
 
 <style scoped>
 .remito-container {
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-family: 'DM Sans', sans-serif;
   font-size: 14px;
   padding: 32px;
   background-color: #fff;


### PR DESCRIPTION
## Summary
- create global stylesheet to use DM Sans everywhere
- import new stylesheet in main.js
- adjust component styles to rely on DM Sans

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fd513ce4832ab057fb406d1a21a0