### PR TITLE
Set dark mode background

### DIFF
--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -39,7 +39,7 @@ export default new Vuetify({
         info:       '#B0B3B8',    // Texto secundario, iconos muted
         success:    '#5beb51',    // (opcional, podés suavizarlo si te parece muy vivo)
         warning:    '#E6B800',    // Amarillo más cálido para warnings
-        background: '#181A1B',    // Fondo general, casi negro
+        background: '#2f2f2f',    // Fondo general para modo oscuro
         surface:    '#232526',    // Cards, paneles, menús flotantes
         menubar:    '#212124',    // Misma barra superior (o quitá el degradé para minimal total)
         card:       '#232526',    // Cards y paneles secundarios

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -239,7 +239,7 @@ export default {
 
 /* ======== ESTILOS PARA MODO OSCURO ======== */
 .modo-dark {
-  background-color: #181818 !important;
+  background-color: #2f2f2f !important;
   color: #fafafa !important;
 }
 .modo-dark .v-card,


### PR DESCRIPTION
## Summary
- set dark theme background color to `#2f2f2f`
- update login view dark-mode background

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490877a2c4832abdc4ece773f84aeb