### PR TITLE
Apply DM Sans font globally

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -274,7 +274,5 @@ export default {
 }
 </style>
 
-<!-- Fuente Roboto -->
-<style>
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
-</style>
+<!-- Fuentes -->
+<!-- DM Sans se carga globalmente desde public/index.html -->


### PR DESCRIPTION
## Summary
- remove leftover Roboto font import in Login view
- DM Sans is already loaded in `public/index.html` and applied in `src/assets/global.css`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490aeaa7ec832a858cc88ed6cf73aa