### PR TITLE
Improve form header theming

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -26,3 +26,9 @@ table tbody tr:nth-child(odd) {
 table tbody tr:nth-child(even) {
   background-color: #d8ecfa;
 }
+/* Form headers color matches menu bar */
+.v-dialog .v-card-title,
+.v-dialog .v-toolbar {
+  background-color: var(--v-primary-base) !important;
+  color: #fff !important;
+}

--- a/src/views/PanelSeguimientos/GuidesTable.vue
+++ b/src/views/PanelSeguimientos/GuidesTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <v-toolbar flat dense color="grey lighten-4">
-      <v-toolbar-title class="subtitle-1 font-weight-medium text--primary">
+    <v-toolbar flat dense color="primary" dark>
+      <v-toolbar-title class="subtitle-1 font-weight-medium">
         Seguimiento de Guías
       </v-toolbar-title>
     </v-toolbar>

--- a/src/views/PanelSeguimientos/OrdersTable.vue
+++ b/src/views/PanelSeguimientos/OrdersTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <v-toolbar flat dense color="grey lighten-4">
-      <v-toolbar-title class="subtitle-1 font-weight-medium text--primary">
+    <v-toolbar flat dense color="primary" dark>
+      <v-toolbar-title class="subtitle-1 font-weight-medium">
         Seguimiento de Órdenes
       </v-toolbar-title>
     </v-toolbar>

--- a/src/views/Productos/ABM Original Flex.vue
+++ b/src/views/Productos/ABM Original Flex.vue
@@ -21,8 +21,8 @@
 
         <v-data-table v-if="selectorDeposito.dato != null" :headers="cabecerasCRUD" :items="listaPosiciones" class="elevation-1" show-select v-model="posicionesSeleccionadas" item-key="Id">
             <template v-slot:top>
-                <v-toolbar flat color="white">
-                    <v-toolbar-title>Posiciones</v-toolbar-title>
+                <v-toolbar flat color="primary" dark>
+                    <v-toolbar-title class="white--text">Posiciones</v-toolbar-title>
                     <v-spacer></v-spacer>
                     <v-dialog v-model="mostrarEdicion" max-width="600px">
                         <template v-slot:activator="{on, attrs}">


### PR DESCRIPTION
## Summary
- ensure forms in Seguimiento tables use the primary menu color
- ensure ABM Original Flex toolbar uses the menu color
- add global style so dialog headers match the selected theme

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497dec3f40832a916814469513d364