### PR TITLE
Handle new API status field

### DIFF
--- a/src/API/Acceso.js
+++ b/src/API/Acceso.js
@@ -16,10 +16,12 @@ const AccesosAAPI = {
 
                     axios({method: payload.Metodo, url: payload.Ruta, headers: payload.Cabeceras})
                         .then(datos => {
-                            if (datos.data.Estado=="OK") {
-                                resolve(datos.data)
+                            const data = datos.data
+                            const estadoOk = data && (data.Estado === "OK" || data.status === "OK")
+                            if (estadoOk) {
+                                resolve(data)
                             } else {
-                                reject(datos.data)
+                                reject(data)
                             }
                         })
                         .catch(error => {


### PR DESCRIPTION
## Summary
- fix API wrapper to support `status: "OK"` responses

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a74be559c832a862b81374bc18dfa