### PR TITLE
Update status chip colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,22 @@ See [Configuration Reference](https://cli.vuejs.org/config/).
 ## Colores de chips de estado
 
 Los componentes de seguimiento utilizan `v-chip` para mostrar el estado
-actual de una orden o guía. A continuación se describen los colores
-asignados a cada estado por la función `getStatusChipColor`:
+actual de una orden o guía. A continuación se describen las clases
+devueltas por `getStatusChipClassTextual` para colorear el fondo de cada
+chip:
 
-| Estado (Órdenes)      | Color background | Color texto |
-|-----------------------|------------------|-------------|
-| Pendiente             | amber lighten-4  | amber darken-3 |
-| Preparado             | blue lighten-4   | blue darken-2 |
-| A distribución        | green lighten-4  | green darken-2 |
-| Anulado               | red lighten-4    | red darken-2 |
-| Retira Cliente        | deep-purple lighten-4 | deep-purple darken-2 |
+| Estado (Órdenes)      | Clases del chip |
+|-----------------------|-----------------|
+| Pendiente             | `warning lighten-2 white--text` |
+| Preparado             | `info lighten-1 white--text` |
+| A distribución        | `success lighten-1 white--text` |
+| Anulado               | `error lighten-2 white--text` |
+| Retira Cliente        | `deep-purple accent-4 white--text` |
 
-| Estado (Guías)        | Color background | Color texto |
-|-----------------------|------------------|-------------|
-| Pedido en preparación, Pedido preparado, En CD, En Planchada, Ruteado, DESPACHADO, En distribución, Entregado, Pedido retirado | green lighten-4 | green darken-2 |
-| No entregado, ANULADO | red lighten-4    | red darken-2 |
-| Entrega parcial       | orange lighten-4 | orange darken-2 |
-| Otros                 | grey lighten-4   | grey darken-1 |
+| Estado (Guías)        | Clases del chip |
+|-----------------------|-----------------|
+| Pedido en preparación, Pedido preparado, En CD, En Planchada, Ruteado, DESPACHADO, En distribución, Entregado, Pedido retirado | `success lighten-2 white--text` |
+| No entregado, ANULADO | `error lighten-2 white--text` |
+| Entrega parcial       | `warning lighten-2 white--text` |
+| Otros                 | `secondary lighten-2 white--text` |
 

--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -1861,37 +1861,58 @@
         // Clases para estados de Órdenes.
         if (['Pendiente', 'Preparado', 'A distribuciòn', 'Anulado', 'Retira Cliente'].includes(estado)) {
           switch (estado) {
-            case 'Pendiente': return 'grey lighten-4 amber--text text--darken-3'; // Amarillo para advertencia.
-            case 'Preparado': return 'grey lighten-4 blue--text text--darken-2'; // Azul para información.
-            case 'A distribuciòn': return 'grey lighten-4 green--text text--darken-2'; // Verde para éxito/distribución.
-            case 'Anulado': return 'grey lighten-4 red--text text--darken-2'; // Rojo para error/anulado.
-            case 'Retira Cliente': return 'grey lighten-4 deep-purple--text text--darken-2'; // Morado para retiro.
-            default: return 'grey lighten-4 grey--text text--darken-1'; // Gris por defecto.
+            case 'Pendiente':
+              return 'warning lighten-2 white--text'; // Advertencia.
+            case 'Preparado':
+              return 'info lighten-1 white--text'; // Información.
+            case 'A distribuciòn':
+              return 'success lighten-1 white--text'; // Distribución en progreso.
+            case 'Anulado':
+              return 'error lighten-2 white--text'; // Anulado o error.
+            case 'Retira Cliente':
+              return 'deep-purple accent-4 white--text'; // Retiro en sucursal.
+            default:
+              return 'secondary lighten-2 white--text'; // Por defecto.
           }
         }
         // Clases para estados de Guías (basadas en `VistaDeTracking.vue`).
-        else if (['Pedido en preparación', 'Pedido preparado', 'En CD', 'En Planchada', 'Ruteado', 'DESPACHADO', 'En distribución', 'Entregado', 'No entregado', 'Entrega parcial', 'Pedido retirado', 'ANULADO'].includes(estado)) {
-            switch (estado) {
-                case 'Entregado':
-                case 'Pedido preparado':
-                case 'Pedido en preparación':
-                case 'En CD':
-                case 'En Planchada':
-                case 'Ruteado':
-                case 'DESPACHADO':
-                case 'En distribución':
-                case 'Pedido retirado':
-                    return 'grey lighten-4 green--text text--darken-2'; // Verde para estados de progreso positivo.
-                case 'No entregado':
-                case 'ANULADO': // Añadido para guías anuladas
-                    return 'grey lighten-4 red--text text--darken-2'; // Rojo para no entregado o anulado.
-                case 'Entrega parcial':
-                    return 'grey lighten-4 orange--text text--darken-2'; // Naranja/Amarillo para parcial.
-                default:
-                    return 'grey lighten-4 grey--text text--darken-1'; // Gris por defecto.
-            }
+        else if (
+          [
+            'Pedido en preparación',
+            'Pedido preparado',
+            'En CD',
+            'En Planchada',
+            'Ruteado',
+            'DESPACHADO',
+            'En distribución',
+            'Entregado',
+            'No entregado',
+            'Entrega parcial',
+            'Pedido retirado',
+            'ANULADO',
+          ].includes(estado)
+        ) {
+          switch (estado) {
+            case 'Entregado':
+            case 'Pedido preparado':
+            case 'Pedido en preparación':
+            case 'En CD':
+            case 'En Planchada':
+            case 'Ruteado':
+            case 'DESPACHADO':
+            case 'En distribución':
+            case 'Pedido retirado':
+              return 'success lighten-2 white--text'; // Progreso positivo.
+            case 'No entregado':
+            case 'ANULADO':
+              return 'error lighten-2 white--text'; // Error o anulado.
+            case 'Entrega parcial':
+              return 'warning lighten-2 white--text'; // Parcial.
+            default:
+              return 'secondary lighten-2 white--text'; // Por defecto.
+          }
         }
-        return 'grey lighten-4 grey--text text--darken-1'; // Color por defecto si el estado no coincide.
+        return 'secondary lighten-2 white--text'; // Por defecto si no coincide.
       },
   
       /**


### PR DESCRIPTION
## Summary
- style status chips with colored backgrounds instead of text colors
- document new classes returned by `getStatusChipClassTextual`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba5b285d0832aaf8c38a2017d9626