### PR TITLE
Fix blue-header style

### DIFF
--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -2071,9 +2071,9 @@
     para darle un fondo azul suave y texto azul oscuro.
   */
   .blue-header th {
-    background-color: #e3f2fd; /* Azul muy suave */
-    color: #1a237e;            /* Texto azul oscuro para contraste */
-    font-weight: 600;          /* Negrita ligera en encabezados */
+    background-color: var(--v-primary-base);
+    color: #fff;
+    font-weight: 600;
   }
   
   /* ============================ */


### PR DESCRIPTION
## Summary
- update `.blue-header th` styles to use the primary color and white text

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba6cb25dc832aafb041e6c0465405