### PR TITLE
Fix order modal cloning

### DIFF
--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -1488,11 +1488,12 @@ import { saveAs } from 'file-saver'
           if (type === 'orden') {
             // Si es una orden, se espera que `item` sea el ID de la orden.
             // Buscamos la orden directamente de `todasLasOrdenes` que ya contiene todos los detalles.
-            dataToModal = this.todasLasOrdenes.find(o => o.IdOrden === item);
-            
+            const found = this.todasLasOrdenes.find(o => o.IdOrden === item);
+            dataToModal = found ? JSON.parse(JSON.stringify(found)) : null;
+
             if (dataToModal) {
               // Los productos ya vienen agrupados en dataToModal.productos
-              // Formatea fechas específicas de la orden para el modal.
+              // Formatea fechas específicas de la orden para el modal sin afectar la lista original.
               dataToModal.Fecha = dataToModal.Fecha ? new Date(dataToModal.Fecha).toLocaleDateString('es-AR') : 'N/A';
               // No necesitamos FechaCreacion, FechaPreparado, FechaDistribucion si ya se usa 'Fecha' como la principal
               // Mapeo de estado numérico a textual


### PR DESCRIPTION
## Summary
- clone order data before formatting when opening order modal

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bad7dacd0832a80e0390e394de7f2