### PR TITLE
Add header-menubar style

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -32,3 +32,9 @@ table tbody tr:nth-child(even) {
   background-color: var(--v-primary-base) !important;
   color: #fff !important;
 }
+
+/* Reusable header class matching the menubar color */
+.header-menubar {
+  background-color: var(--v-menubar-base);
+  color: #fff;
+}

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -8,7 +8,7 @@
           <v-col cols="12" sm="8" md="6" lg="4">
             <v-card :class="['elevation-6', 'login-card', { 'modo-dark': $vuetify.theme.dark }]">
               <!-- Barra superior con título e icono -->
-              <v-toolbar color="primary" dark flat>
+              <v-toolbar flat class="header-menubar">
                 <v-toolbar-title class="text-h5">Bienvenido</v-toolbar-title>
                 <v-spacer />
                 <v-icon large>mdi-forklift</v-icon>

--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -99,8 +99,8 @@
             <v-tabs-items v-model="tab">
               <v-tab-item value="tab-ordenes">
                 <v-card-text>
-                  <v-toolbar flat dense color="grey lighten-4">
-                    <v-toolbar-title class="subtitle-1 font-weight-medium text--primary">
+                  <v-toolbar flat dense class="header-menubar">
+                    <v-toolbar-title class="subtitle-1 font-weight-medium">
                       Seguimiento de Órdenes
                     </v-toolbar-title>
                   </v-toolbar>
@@ -252,8 +252,8 @@
   
               <v-tab-item value="tab-guias">
                 <v-card-text>
-                  <v-toolbar flat dense color="grey lighten-4">
-                    <v-toolbar-title class="subtitle-1 font-weight-medium text--primary">
+                  <v-toolbar flat dense class="header-menubar">
+                    <v-toolbar-title class="subtitle-1 font-weight-medium">
                       Seguimiento de Guías
                     </v-toolbar-title>
                   </v-toolbar>

--- a/src/views/Productos/ABM Original Flex.vue
+++ b/src/views/Productos/ABM Original Flex.vue
@@ -21,7 +21,7 @@
 
         <v-data-table v-if="selectorDeposito.dato != null" :headers="cabecerasCRUD" :items="listaPosiciones" class="elevation-1" show-select v-model="posicionesSeleccionadas" item-key="Id">
             <template v-slot:top>
-                <v-toolbar flat color="primary" dark>
+                <v-toolbar flat class="header-menubar">
                     <v-toolbar-title class="white--text">Posiciones</v-toolbar-title>
                     <v-spacer></v-spacer>
                     <v-dialog v-model="mostrarEdicion" max-width="600px">

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -5,7 +5,7 @@
         <v-row align="center" justify="center">
           <v-col cols="12" sm="8" md="6" lg="4">
             <v-card class="elevation-6 login-card">
-              <v-toolbar color="primary" dark flat>
+              <v-toolbar flat class="header-menubar">
                 <v-toolbar-title class="text-h5">
                   Restablecer contraseña
                 </v-toolbar-title>


### PR DESCRIPTION
## Summary
- add `.header-menubar` style to share menubar colors
- apply the new style to `Login.vue`, `ResetPassword.vue`, `Seguimientos.vue` and `ABM Original Flex.vue`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb8032308832aa215633e715ec8b9