### PR TITLE
Update chip status classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ chip:
 
 | Estado (Órdenes)      | Clases del chip |
 |-----------------------|-----------------|
-| Pendiente             | `warning lighten-2 white--text` |
-| Preparado             | `info lighten-1 white--text` |
-| A distribución        | `success lighten-1 white--text` |
+| Pendiente             | `chip-pendiente` |
+| Preparado             | `chip-preparada` |
+| A distribución        | `chip-despachada` |
 | Anulado               | `error lighten-2 white--text` |
-| Retira Cliente        | `deep-purple accent-4 white--text` |
+| Retira Cliente        | `chip-despachada` |
 
 | Estado (Guías)        | Clases del chip |
 |-----------------------|-----------------|

--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -1897,17 +1897,16 @@ import { saveAs } from 'file-saver'
         if (['Pendiente', 'Preparado', 'A distribuciòn', 'Anulado', 'Retira Cliente'].includes(estado)) {
           switch (estado) {
             case 'Pendiente':
-              return 'warning lighten-2 white--text'; // Advertencia.
+              return 'chip-pendiente'
             case 'Preparado':
-              return 'info lighten-1 white--text'; // Información.
+              return 'chip-preparada'
             case 'A distribuciòn':
-              return 'success lighten-1 white--text'; // Distribución en progreso.
-            case 'Anulado':
-              return 'error lighten-2 white--text'; // Anulado o error.
             case 'Retira Cliente':
-              return 'deep-purple accent-4 white--text'; // Retiro en sucursal.
+              return 'chip-despachada'
+            case 'Anulado':
+              return 'error lighten-2 white--text'
             default:
-              return 'secondary lighten-2 white--text'; // Por defecto.
+              return 'secondary lighten-2 white--text'
           }
         }
         // Clases para estados de Guías (basadas en `VistaDeTracking.vue`).
@@ -2373,5 +2372,21 @@ import { saveAs } from 'file-saver'
   }
   .timeline-step.despachada::before {
     background-color: #2d8bba;
+  }
+
+  /* === Chip color classes (comparten valores con el timeline) === */
+  .chip-pendiente {
+    background-color: #c81e2b;
+    color: #fff;
+  }
+
+  .chip-preparada {
+    background-color: #f8b421;
+    color: #fff;
+  }
+
+  .chip-despachada {
+    background-color: #2d8bba;
+    color: #fff;
   }
   </style>


### PR DESCRIPTION
## Summary
- add chip color classes matching timeline colors
- use chip classes in `getStatusChipClassTextual`
- document new chip classes in README

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c37ff4e48832a9b827320862e8dc6