### PR TITLE
Fix date filtering in GuiasTab

### DIFF
--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -407,13 +407,13 @@ import { saveAs } from 'file-saver'
         // 2) Filtrar por rango de fechas (basado en `FechaOriginalDate` de la guía)
         if (fechaDesdeNormalized) {
           filtrado = filtrado.filter((g) => {
-            const guiaDateNormalized = this.normalizeDateToStartOfDay(g.FechaOriginal);
+            const guiaDateNormalized = this.normalizeDateToStartOfDay(g.FechaOriginalDate);
             return guiaDateNormalized && guiaDateNormalized.getTime() >= fechaDesdeNormalized.getTime();
           });
         }
         if (fechaHastaNormalized) {
           filtrado = filtrado.filter((g) => {
-            const guiaDateNormalized = this.normalizeDateToStartOfDay(g.FechaOriginal);
+            const guiaDateNormalized = this.normalizeDateToStartOfDay(g.FechaOriginalDate);
             return guiaDateNormalized && guiaDateNormalized.getTime() <= fechaHastaNormalized.getTime();
           });
         }


### PR DESCRIPTION
## Summary
- ensure guia filters use the original Date object

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c48080d88832ab63f1db7810ce412