### PR TITLE
Add styles for Entregado status

### DIFF
--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -1346,7 +1346,7 @@ import { saveAs } from 'file-saver'
           en_cd: 'despachada',
           en_distribucion: 'despachada',
           retirado: 'despachada',
-          entregado: 'despachada',
+          entregado: 'entregado',
           parcial: 'despachada',
           no_entregado: 'despachada'
         };
@@ -1412,6 +1412,7 @@ import { saveAs } from 'file-saver'
         ) {
           switch (estado) {
             case 'Entregado':
+              return 'chip-entregado';
             case 'Pedido preparado':
             case 'Pedido en preparación':
             case 'En CD':
@@ -1858,6 +1859,15 @@ import { saveAs } from 'file-saver'
     background-color: #2d8bba;
   }
 
+  .timeline-step.entregado .timeline-icon-container,
+  .timeline-line.entregado {
+    background-color: #4caf50;
+    color: #fff;
+  }
+  .timeline-step.entregado::before {
+    background-color: #4caf50;
+  }
+
   /* === Chip color classes (comparten valores con el timeline) === */
   .chip-pendiente {
     background-color: #c81e2b;
@@ -1871,6 +1881,11 @@ import { saveAs } from 'file-saver'
 
   .chip-despachada {
     background-color: #2d8bba;
+    color: #fff;
+  }
+
+  .chip-entregado {
+    background-color: #4caf50;
     color: #fff;
   }
   </style>

--- a/src/views/PanelSeguimientos/components/SeguimientoModal.vue
+++ b/src/views/PanelSeguimientos/components/SeguimientoModal.vue
@@ -371,8 +371,12 @@ export default {
 .timeline-step.despachada .timeline-icon-container,
 .timeline-line.despachada { background-color: #2d8bba; color: #fff; }
 .timeline-step.despachada::before { background-color: #2d8bba; }
+.timeline-step.entregado .timeline-icon-container,
+.timeline-line.entregado { background-color: #4caf50; color: #fff; }
+.timeline-step.entregado::before { background-color: #4caf50; }
 .chip-pendiente { background-color: #c81e2b; color: #fff; }
 .chip-preparada { background-color: #f8b421; color: #fff; }
 .chip-despachada { background-color: #2d8bba; color: #fff; }
+.chip-entregado { background-color: #4caf50; color: #fff; }
 </style>
 


### PR DESCRIPTION
## Summary
- support Entregado styling for chips and timeline steps
- map Entregado status in getStatusChipClassTextual
- color Entregado step as success in timeline

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6289b728832a884c7d85abd7e945