### PR TITLE
Fix date display in SeguimientoModal

### DIFF
--- a/src/views/PanelSeguimientos/components/SeguimientoModal.vue
+++ b/src/views/PanelSeguimientos/components/SeguimientoModal.vue
@@ -177,7 +177,10 @@
                     <span class="subtitle-2 font-weight-medium">
                       {{ paso.nombre }}
                     </span>
-                    <span v-if="paso.fecha" class="caption text--secondary">
+                    <span
+                      v-if="paso.fecha && paso.fecha !== 'N/A' && paso.fecha !== 'Invalid date'"
+                      class="caption text--secondary"
+                    >
                       – {{ paso.fecha }}
                     </span>
                     <span v-if="paso.descripcion" class="caption mt-1 text--secondary">


### PR DESCRIPTION
## Summary
- avoid showing `– N/A` for timeline steps that do not have a valid date

## Testing
- `npm test` *(fails: start-server-and-test: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c643e6188832a9a4bf50f68c79d92