### PR TITLE
Load guide product list in modal

### DIFF
--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -998,20 +998,31 @@ import { saveAs } from 'file-saver'
               throw new Error('No se encontraron detalles válidos para esta orden.');
             }
           } else if (type === 'guia') {
-            // Si es una guía, se espera que `item` ya sea el objeto completo de la guía de la tabla.
+            // Para las guías, obtenemos el detalle completo desde la API utilizando su Id.
             console.log("openModal: Procesando datos de guía para modal:", item);
-            dataToModal = { ...item }; // Clona el objeto para evitar mutaciones directas en la lista de la tabla.
-            dataToModal.productos = []; // Las guías no tienen un `productos` por defecto como las órdenes.
-  
+
+            const response = await guias.getById(item.Id);
+            const guiaCompleta = (response && response.data)
+              ? response.data
+              : (response && response.Id ? response : null);
+
+            if (!guiaCompleta) {
+              throw new Error('No se encontraron detalles válidos para esta guía.');
+            }
+
+            dataToModal = { ...item, ...guiaCompleta };
+            dataToModal.productos = Array.isArray(guiaCompleta.productos) ? guiaCompleta.productos : [];
+
             // Formatea fechas específicas de la guía para el modal.
             dataToModal.FechaOriginal = dataToModal.FechaOriginal ? new Date(dataToModal.FechaOriginal).toLocaleDateString('es-AR') : 'N/A';
             // Para la fecha de no entrega, se usa la `Fecha` de la guía si el estado es `NO ENTREGADO`.
             if (dataToModal.Estado === 'NO ENTREGADO' && dataToModal.Fecha) {
-                dataToModal.FechaNoEntregado = new Date(dataToModal.Fecha).toLocaleDateString('es-AR');
+              dataToModal.FechaNoEntregado = new Date(dataToModal.Fecha).toLocaleDateString('es-AR');
             } else {
               dataToModal.FechaNoEntregado = 'N/A';
             }
-             console.log("openModal: Datos de guía para modal procesados:", dataToModal);
+
+            console.log("openModal: Datos de guía para modal procesados:", dataToModal);
           }
   
           // Si se obtuvieron datos válidos para el modal, los asigna y lo muestra.

--- a/src/views/PanelSeguimientos/components/SeguimientoModal.vue
+++ b/src/views/PanelSeguimientos/components/SeguimientoModal.vue
@@ -242,7 +242,7 @@
                     </template>
                   </v-simple-table>
                   <v-alert v-else type="info" class="ma-4" dense outlined>
-                    No hay productos registrados en esta orden.
+                    No hay productos registrados en esta {{ modalType === 'orden' ? 'orden' : 'guía' }}.
                   </v-alert>
                 </v-card-text>
               </v-card>


### PR DESCRIPTION
## Summary
- load product list when opening guide detail
- show appropriate message if guide has no products

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c64d1f2f4832a9540761e3aab4b0e