### PR TITLE
Add excel export for single guide

### DIFF
--- a/src/views/PanelSeguimientos/components/SeguimientoModal.vue
+++ b/src/views/PanelSeguimientos/components/SeguimientoModal.vue
@@ -254,8 +254,19 @@
       <v-divider />
 
       <v-card-actions class="justify-end">
-        <v-btn color="primary" text @click="$emit('descargar-orden-excel-individual', modalData)">
-          Descargar Orden
+        <v-btn
+          color="primary"
+          text
+          @click="
+            $emit(
+              modalType === 'guia'
+                ? 'descargar-guia-excel-individual'
+                : 'descargar-orden-excel-individual',
+              modalData
+            )
+          "
+        >
+          Descargar {{ modalType === 'guia' ? 'Guía' : 'Orden' }}
         </v-btn>
         <v-btn text color="primary" @click="$emit('close')">Cerrar</v-btn>
       </v-card-actions>


### PR DESCRIPTION
## Summary
- allow SeguimientoModal to emit guia export event
- hook guia export to parent component
- implement `descargarGuiaExcelIndividual` to save a single guide and its history to Excel

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c65d46a60832a899207571814ae9e