### PR TITLE
Add ability to fetch only products with stock

### DIFF
--- a/src/store/productosV3.js
+++ b/src/store/productosV3.js
@@ -395,11 +395,19 @@ const productosV3= {
                 .then(data => {
                     resolve(data)
                 })
-                .catch(puteada => { 
-                    reject(puteada) 
+                .catch(puteada => {
+                    reject(puteada)
                 })
             }
-        )            
+        )
+    },
+
+    async getAllConStock(idEmpresa) {
+        return new Promise((resolve, reject) => {
+            API.acceder({Ruta: `/productos/allConStock/${idEmpresa}`, Cartel: 'Obteniendo datos ...'})
+                .then(data => resolve(data))
+                .catch(err => reject(err));
+        });
     },
 
     async getMovimientosByPeriodoAndEmpresaAndArticulo(idEmpresa, fechaDesde, fechaHasta, idArticulo) {

--- a/src/views/Stock/Stock.vue
+++ b/src/views/Stock/Stock.vue
@@ -7,7 +7,7 @@
         </v-row>
         <v-row v-if="idEmpresa>0" class="py-0">
             <v-col class="py-0 my-0">
-                <v-checkbox class="my-0" @change="changeVerSoloConStock" v-model="verSoloConStock" label="Ver solo artículos con stock"></v-checkbox>
+                <v-checkbox class="my-0" @change="changeVerSoloConStock" v-model="verSoloConStock" :label="verSoloConStock ? 'Ver todos los artículos' : 'Ver solo artículos con stock'"></v-checkbox>
             </v-col>
             <v-col class="py-0" v-show="empresaElegida.StockPosicionado">
                 <v-checkbox class="my-0" @change="changeVerSoloStockSinPosicionar" v-model="verSoloConStockSinPosicionar" label="Ver solo artículos con stock sin posicionar"></v-checkbox>
@@ -328,7 +328,7 @@ export default {
             tieneLOTE: false,
             tienePART: false,
             verSoloConStockSinPosicionar: false,
-            verSoloConStock: false,
+            verSoloConStock: true,
             stockTotal: 0,
             stockSinPosicionar: 0,
             stockPosicionado: 0,
@@ -1567,7 +1567,10 @@ export default {
                     console.log(error)
                 })
             }else{
-                productosV3.getAllProductosByEmpresa(this.idEmpresa)
+                const apiCall = this.verSoloConStock
+                    ? productosV3.getAllConStock(this.idEmpresa)
+                    : productosV3.getAllProductosByEmpresa(this.idEmpresa)
+                apiCall
                     .then(respuesta => {
                         respuesta.forEach(unProducto => {
                             if(unProducto.StockComprometido == null){


### PR DESCRIPTION
## Summary
- add `getAllConStock` helper in productosV3 store
- default to showing only products with stock in Stock view
- toggle checkbox label text
- call the new API when needed

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6efc2d34832a846b7cea69a24764