### PR TITLE
Add local dev environment configuration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VUE_APP_API_URL="http://localhost:8128"

--- a/README.md
+++ b/README.md
@@ -40,3 +40,21 @@ chip:
 | Entrega parcial       | `warning lighten-2 white--text` |
 | Otros                 | `secondary lighten-2 white--text` |
 
+## Running against a local backend
+
+To use the frontend with a backend running on your machine you can create
+a `.env.development` file in the project root:
+
+```bash
+VUE_APP_API_URL="http://localhost:8128"
+```
+
+Then start the development server:
+
+```bash
+npm run serve
+```
+
+Vue CLI will load `.env.development` automatically and API requests will be
+sent to `http://localhost:8128`.
+

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,8 @@ Vue.config.productionTip = false
 const apiUrl = process.env.VUE_APP_API_URL
 if (!apiUrl) {
   console.error('⚠️ VUE_APP_API_URL no está definida en .env')
+} else if (apiUrl.includes('localhost')) {
+  axios.defaults.baseURL = apiUrl
 } else {
   axios.defaults.baseURL = apiUrl.replace(/^http:/, 'https:')
 }


### PR DESCRIPTION
## Summary
- add `.env.development` for running frontend with local backend
- adjust Axios setup to keep `http:` protocol when using localhost
- document how to run against the local backend

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2f809c90832a8f15101fdee41d67