### PR TITLE
Add PrepararOrden route and barcode workflow

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -38,6 +38,7 @@ const routes = [
   { path: '/Informes/Ingresos', name: 'Informes_Ingresos', component: () => import('../views/Informes/Ingresos.vue'), meta: { tituloPagina: 'Informes - Ingresos' } },
   { path: '/ImportacionOrdenes', name: 'ImportacionOrdenes', component: () => import('../views/Ordenes/ImportacionOrdenes.vue'), meta: { tituloPagina: 'Importación de órdenes' } },
   { path: '/OrdenesSalida', name: 'OrdenesSalida', component: () => import('../views/Ordenes/OrdenesSalida.vue'), meta: { tituloPagina: 'Salida de órdenes' } },
+  { path: '/Ordenes/PrepararOrden/:idOrden', name: 'PrepararOrden', component: () => import('../views/Ordenes/PrepararOrden.vue'), meta: { tituloPagina: 'Preparar Orden' } },
   { path: '/Ordenes/CreacionManual', name: 'OrdenesCreacionManual', component: () => import('../views/Ordenes/CreacionManual.vue'), meta: { tituloPagina: 'Creación manual de órdenes' } },
   { path: '/Productos/ABM', name: 'ProductosABM', component: () => import('../views/Productos/ABM.vue'), meta: { tituloPagina: 'Creación de productos' } },
   { path: '/Estadisticas', name: 'Estadisticas', component: () => import('../views/Estadisticas.vue'), meta: { tituloPagina: 'Estadísticas' } },

--- a/src/views/Ordenes/OrdenesSalida.vue
+++ b/src/views/Ordenes/OrdenesSalida.vue
@@ -388,26 +388,9 @@ async salidaExpress() {
 },
 
         botonPrevisualizarOrdenClick() {
-            let detalle=""
-            let numeroItem=0
-          
-            // iteramos el detalle para mostrar unidades, nombre y barcode por cada producto
-            if(this.tieneLOTE){
-                this.detalleOrdenEnCurso.forEach(element => {
-                numeroItem++
-                detalle+=numeroItem+") "+element.Unidades+" x "+element.Productos+" - BoxNumber:("+element.lote+ ") SerialNumber:("+element.Barcode+") PartNumber:("+ element.PartNumber +") - Salidos: "+element.CantidadSalida+";"   
-                })
-            } else {
-                this.detalleOrdenEnCurso.forEach(element => {
-                numeroItem++
-                detalle+=numeroItem+") "+element.Unidades+" x "+element.Productos+" ("+element.Barcode+")"+" - Salidos: "+element.CantidadSalida+";"   
-                })
+            if (this.selectorOrden.dato) {
+                router.push(`/Ordenes/PrepararOrden/${this.selectorOrden.dato}`)
             }
-            const mensajeAMostrar = {   titulo: 'Detalle de la orden', 
-                                        mensaje: detalle 
-                                    }
-            this.mostrarMensaje(mensajeAMostrar)
-            this.enfocarBarcodeArticulo()         
         },
 
         async clickFinalizarIngresarBultos() {


### PR DESCRIPTION
## Summary
- register `/Ordenes/PrepararOrden/:idOrden` route
- repurpose magnify button in `OrdenesSalida.vue` to open Preparar Orden
- enhance `PrepararOrden.vue` with barcode reader and editable quantities
- highlight rows according to validation and show process button only when valid

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2f82296c832aa3504b0e18701221