### PR TITLE
Fix product name mapping

### DIFF
--- a/src/views/Ordenes/PrepararOrden.vue
+++ b/src/views/Ordenes/PrepararOrden.vue
@@ -124,7 +124,8 @@ export default {
         ...d,
         validado: false,
         CantidadSalida: 0,
-        NombreProducto: d.Producto?.Nombre || d.NombreProducto || d.Nombre || d.Descripcion || 'Sin nombre',
+        NombreProducto: d.Producto?.Nombre || d.NombreProducto || d.Nombre ||
+          d.Descripcion || d.Productos || 'Sin nombre',
         Posicion: d.Posicion || d.PosicionNombre || d.Ubicacion || null,
         Barcode: d.Barcode || d.CodeEmpresa,
         CodeEmpresa: d.CodeEmpresa


### PR DESCRIPTION
## Summary
- include `d.Productos` when mapping product names in `PrepararOrden`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e499e0b84832ab5c7755e54d25940