### PR TITLE
Wrap ordenesV3 calls with error handling

### DIFF
--- a/src/views/Guias/GenerarDesdeOrdenes.vue
+++ b/src/views/Guias/GenerarDesdeOrdenes.vue
@@ -465,7 +465,11 @@ export default {
         callback: async response => {
           if (response=="Si") {
             for (const unaOrden of this.ordenesSeleccionadas) {
-              await ordenes.marcarRetiraCliente(unaOrden.Id, this.fechaMarcarComoRetiraCliente)
+              try {
+                await ordenes.marcarRetiraCliente(unaOrden.Id, this.fechaMarcarComoRetiraCliente)
+              } catch (e) {
+                store.dispatch('snackbar/mostrar', 'Error al obtener la orden')
+              }
             }
             this.ordenesSeleccionadas=[]
             this.popularListaDeOrdenes()
@@ -644,30 +648,32 @@ export default {
 
       this.refrescarListaOrdenesAProcesar()
     },
-    popularListaDeOrdenes() {
-      ordenes.getPreparadasNoGuias()
-        .then(response => {
-          response.forEach(element => {
-            element.Fecha=element.Fecha.substr(0, 10)
-          });
-          response.sort( (a, b) => a.Fecha>b.Fecha ?  -1 : 1)
-          this.ordenes=response
-          this.filtrarOrdenes()
+    async popularListaDeOrdenes() {
+      try {
+        const response = await ordenes.getPreparadasNoGuias()
+        response.forEach(element => {
+          element.Fecha = element.Fecha.substr(0, 10)
         })
-        .catch(error => {console.log("Error", error)})
+        response.sort((a, b) => a.Fecha > b.Fecha ? -1 : 1)
+        this.ordenes = response
+        this.filtrarOrdenes()
+      } catch (e) {
+        store.dispatch('snackbar/mostrar', 'Error al obtener la orden')
+      }
     },
 
-    popularListaDeOrdenesByIdEmpresa() {
-      ordenes.getPreparadasNoGuiasByIdEmpresa(this.idEmpresa)
-        .then(response => {
-          response.forEach(element => {
-            element.Fecha=element.Fecha.substr(0, 10)
-          });
-          response.sort( (a, b) => a.Fecha>b.Fecha ?  -1 : 1)
-          this.ordenes=response
-          this.filtrarOrdenes()
+    async popularListaDeOrdenesByIdEmpresa() {
+      try {
+        const response = await ordenes.getPreparadasNoGuiasByIdEmpresa(this.idEmpresa)
+        response.forEach(element => {
+          element.Fecha = element.Fecha.substr(0, 10)
         })
-        .catch(error => {console.log("Error", error)})
+        response.sort((a, b) => a.Fecha > b.Fecha ? -1 : 1)
+        this.ordenes = response
+        this.filtrarOrdenes()
+      } catch (e) {
+        store.dispatch('snackbar/mostrar', 'Error al obtener la orden')
+      }
     },
     mostrarMensaje(mensaje, titulo) {
       store.dispatch("alertDialog/mostrar", {titulo, mensaje, botonPrimario: "Entendido"})

--- a/src/views/Ordenes/OrdenesSalida.vue
+++ b/src/views/Ordenes/OrdenesSalida.vue
@@ -458,10 +458,14 @@ async registrarProcesamientoOrden() {
             this.mostrarMensaje({titulo: "Registración correcta! 👍", mensaje: "La salida de la orden ha sido registrada exitosamente"});
 
             // Actualización de datos y generación del PDF
-            const datosOrden = await ordenesV3.getById(this.ordenEnCurso[0].Id);
-            const ordenActualizada = await ordenes.actions.getDatosOrden(datosOrden);
-            const pdfEtiqueta = await ordenes.generarOrdenEtiquetaEnPDFChicaUnaPorHoja(ordenActualizada);
-            pdfEtiqueta.save("etiqueta_" + ordenActualizada[0].Orden.Numero + ".pdf");
+            try {
+                const datosOrden = await ordenesV3.getById(this.ordenEnCurso[0].Id);
+                const ordenActualizada = await ordenes.actions.getDatosOrden(datosOrden);
+                const pdfEtiqueta = await ordenes.generarOrdenEtiquetaEnPDFChicaUnaPorHoja(ordenActualizada);
+                pdfEtiqueta.save("etiqueta_" + ordenActualizada[0].Orden.Numero + ".pdf");
+            } catch (e) {
+                store.dispatch('snackbar/mostrar', 'Error al obtener la orden');
+            }
         } catch (error) {
             this.mostrarMensaje({titulo: "Error", mensaje: error});
         }


### PR DESCRIPTION
## Summary
- show friendly snackbar when fetching order fails in `OrdenesSalida`
- handle errors in `popularListaDeOrdenes` and `marcarComoRetiraCliente`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4a439254832aa9020814caf55237