### PR TITLE
Add back button to PrepararOrden actions

### DIFF
--- a/src/views/Ordenes/PrepararOrden.vue
+++ b/src/views/Ordenes/PrepararOrden.vue
@@ -80,6 +80,9 @@
       <v-btn class="ml-2" outlined @click="window.print()">
         Imprimir
       </v-btn>
+      <v-btn class="ml-2" outlined @click="$router.back()">
+        Volver
+      </v-btn>
       <v-btn class="ml-2" outlined color="success" @click="descargarExcel">
         Descargar Excel
       </v-btn>


### PR DESCRIPTION
## Summary
- add `Volver` button to return to previous page in PrepararOrden view

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4bca2f78832a98ff78e8c261cc0e