### PR TITLE
Handle multiple positions in orders

### DIFF
--- a/src/views/Ordenes/PrepararOrden.vue
+++ b/src/views/Ordenes/PrepararOrden.vue
@@ -133,7 +133,10 @@ export default {
         CantidadSalida: 0,
         NombreProducto: d.Producto?.Nombre || d.NombreProducto || d.Nombre ||
           d.Descripcion || d.Productos || 'Sin nombre',
-        Posicion: d.Posicion || d.PosicionNombre || d.Ubicacion || null,
+        Posicion:
+          (Array.isArray(d.Posiciones) && d.Posiciones.length
+            ? d.Posiciones.map(p => p.Posicion).join(', ')
+            : d.Posicion || d.PosicionNombre || d.Ubicacion || null),
         Barcode: d.Barcode || d.CodeEmpresa,
         CodeEmpresa: d.CodeEmpresa
       }))


### PR DESCRIPTION
## Summary
- expand `Posicion` mapping in `PrepararOrden.vue` to join all `Posiciones`
- keep using the same `Posicion` field when generating Excel

## Testing
- `npm run test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e506817ac832ab3c1315ad56dd803