### PR TITLE
Fix menu overflow style

### DIFF
--- a/src/components/MenuPrincipal.vue
+++ b/src/components/MenuPrincipal.vue
@@ -473,12 +473,14 @@ export default {
 /* Barra horizontal súper compacta: nunca hace overflow, los botones se achican */
 .menu-horizontal-compacta {
   display: flex !important;
-  flex-wrap: nowrap !important;
+  flex-wrap: wrap !important; /* permite que los elementos bajen a otra línea */
+  overflow-x: auto !important; /* añade scroll si aún así no entran */
   gap: 1px !important;
   align-items: center;
+  max-width: 100%;
 }
 .menu-horizontal-compacta > * {
-  flex-shrink: 1 !important;
+  flex-shrink: 0 !important; /* evita que los botones se encojan demasiado */
 }
 
 /* Botones más chicos */


### PR DESCRIPTION
## Summary
- allow wrapping or scrolling for `.menu-horizontal-compacta`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee1782db0832aa35a9befafcde8ff