### PR TITLE
Add back button to PrepararOrden

### DIFF
--- a/src/views/Ordenes/PrepararOrden.vue
+++ b/src/views/Ordenes/PrepararOrden.vue
@@ -2,6 +2,9 @@
   <v-container class="remito-container">
 
     <!-- TÍTULO -->
+    <v-btn icon class="mb-2" @click="$router.back()">
+      <v-icon>mdi-arrow-left</v-icon>
+    </v-btn>
     <h2 class="remito-titulo">ORDEN DE SALIDA</h2>
 
     <!-- CABECERA -->


### PR DESCRIPTION
## Summary
- add quick back button near the header in PrepararOrden

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee347c070832ab26eb7efb9748588