### PR TITLE
Load cards quickly with stock summary

### DIFF
--- a/src/store/productosV3.js
+++ b/src/store/productosV3.js
@@ -411,6 +411,20 @@ const productosV3= {
             .then(productos => productos.filter(p => p.Stock > 0));
     },
 
+    // Devuelve un resumen de stock para las tarjetas de la vista de Stock
+    async getResumenStock(idEmpresa) {
+        return new Promise(
+            function(resolve, reject) {
+                API.acceder({
+                    Ruta: `/productos/resumenStock/${idEmpresa}`,
+                    Cartel: "Obteniendo resumen..."
+                })
+                .then(data => { resolve(data) })
+                .catch(err => { reject(err) })
+            }
+        )
+    },
+
     async getMovimientosByPeriodoAndEmpresaAndArticulo(idEmpresa, fechaDesde, fechaHasta, idArticulo) {
         return new Promise (
             function (resolve, reject) {


### PR DESCRIPTION
## Summary
- add API for stock summary
- show summary counts on cards when selecting a company
- load full product list only when a card is clicked

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f076a0980832a94420102e16f3be1