### PR TITLE
Add barcode column to order prep view and Excel export

### DIFF
--- a/src/views/Ordenes/PrepararOrden.vue
+++ b/src/views/Ordenes/PrepararOrden.vue
@@ -48,6 +48,7 @@
       <thead>
         <tr>
           <th>Producto</th>
+          <th>Barcode</th>
           <th>Posición</th>
           <th>Unidades</th>
           <th>Cant. Salida</th>
@@ -61,6 +62,7 @@
           :class="rowClass(item)"
         >
           <td>{{ item.NombreProducto }}</td>
+          <td>{{ item.Barcode || item.CodeEmpresa }}</td>
           <td>{{ item.Posicion || '-' }}</td>
           <td>{{ item.Unidades }}</td>
           <td class="text-center">
@@ -198,6 +200,7 @@ export default {
       const sheet = workbook.addWorksheet('Orden')
       sheet.columns = [
         { header: 'Producto', key: 'producto', width: 30 },
+        { header: 'Barcode', key: 'barcode', width: 20 },
         { header: 'Posicion', key: 'posicion', width: 15 },
         { header: 'Unidades', key: 'unidades', width: 10 },
         { header: 'Cant. Salida', key: 'salida', width: 12 }
@@ -205,6 +208,7 @@ export default {
       this.detalle.forEach(d => {
         sheet.addRow({
           producto: d.NombreProducto,
+          barcode: d.Barcode,
           posicion: d.Posicion || '',
           unidades: d.Unidades,
           salida: d.CantidadSalida


### PR DESCRIPTION
## Summary
- show barcode data in `PrepararOrden` table
- export barcode column to Excel spreadsheet

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f09307138832aa9efc1c3363aa8ad