### PR TITLE
Fix menu button case style

### DIFF
--- a/src/components/MenuPrincipal.vue
+++ b/src/components/MenuPrincipal.vue
@@ -485,6 +485,7 @@ export default {
 /* Botones compactos */
 .menu-horizontal-compacta .v-btn {
   font-size: clamp(8px, 1vw, 12px) !important; /* reduce el texto en pantallas pequeñas */
+  text-transform: none !important;
   padding: 0 7px !important;
   margin: 0 !important;
   min-width: 0 !important;


### PR DESCRIPTION
## Summary
- keep original casing of menu names by disabling text-transform on menu buttons

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f12490230832ab8e75eb9b788cbc6