### PR TITLE
Fix menu wrapping in toolbar

### DIFF
--- a/src/components/MenuPrincipal.vue
+++ b/src/components/MenuPrincipal.vue
@@ -472,7 +472,7 @@ export default {
 /* Barra horizontal súper compacta: nunca hace overflow, los botones se achican */
 .menu-horizontal-compacta {
   display: flex !important;
-  flex-wrap: wrap !important; /* permite que los elementos bajen a otra línea */
+  flex-wrap: nowrap !important; /* mantiene todos los elementos en una sola línea */
   overflow-x: hidden !important; /* se elimina la barra de desplazamiento */
   gap: 1px !important;
   align-items: center;


### PR DESCRIPTION
## Summary
- prevent horizontal menu from wrapping by default

## Testing
- `npm test --silent` *(fails: start-server-and-test: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1300eb18832a9909514da88a4b9a