### PR TITLE
Stop fetching stock summary from API

### DIFF
--- a/src/store/productosV3.js
+++ b/src/store/productosV3.js
@@ -411,7 +411,10 @@ const productosV3= {
             .then(productos => productos.filter(p => p.Stock > 0));
     },
 
-    // Devuelve un resumen de stock para las tarjetas de la vista de Stock
+    // La carga de tarjetas se realiza localmente con los productos obtenidos
+    // por `popularListaProductos`. Se deja comentada esta función que antes
+    // consultaba un resumen al backend por si vuelve a ser necesaria.
+    /*
     async getResumenStock(idEmpresa) {
         return new Promise(
             function(resolve, reject) {
@@ -424,6 +427,7 @@ const productosV3= {
             }
         )
     },
+    */
 
     async getMovimientosByPeriodoAndEmpresaAndArticulo(idEmpresa, fechaDesde, fechaHasta, idArticulo) {
         return new Promise (

--- a/src/views/Stock/Stock.vue
+++ b/src/views/Stock/Stock.vue
@@ -1719,7 +1719,10 @@ export default {
                         }
                     }
 
-                    // Obtiene solo el resumen para mostrar en las tarjetas
+                    // Cargamos toda la lista de productos y armamos las tarjetas
+                    this.popularListaProductos()
+                    /*
+                    // Anteriormente se obtenía un resumen desde el backend
                     productosV3.getResumenStock(idEmpresaElegida)
                         .then(resumen => {
                             this.actualizarCardsDesdeResumen(resumen)
@@ -1729,6 +1732,7 @@ export default {
                         .catch(() => {
                             this.cards = []
                         })
+                    */
                 })
         },
         mostrarMensaje(titulo, mensaje){


### PR DESCRIPTION
## Summary
- load product list directly when selecting an enterprise
- keep old `getResumenStock` helper commented out

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f68a255c8832a81d36fdebc1d6f4e