### PR TITLE
Add company guides tracking tab with PDF export

### DIFF
--- a/src/views/PanelSeguimientos/components/GuiaEmpresaModal.vue
+++ b/src/views/PanelSeguimientos/components/GuiaEmpresaModal.vue
@@ -1,0 +1,117 @@
+<template>
+  <v-dialog v-model="show" scrollable max-width="650px">
+    <v-card>
+      <v-card-title class="justify-space-between">
+        <span class="text-h6">Detalle Guía: {{ guia?.Comprobante }}</span>
+        <v-btn icon @click="$emit('close')" aria-label="Cerrar detalle">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </v-card-title>
+      <v-divider />
+      <v-card-text>
+        <v-list dense>
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title class="subtitle-2 font-weight-medium">
+                Destino:
+              </v-list-item-title>
+              <v-list-item-subtitle>{{ guia?.NombreDestino }}</v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title class="subtitle-2 font-weight-medium">
+                Bultos:
+              </v-list-item-title>
+              <v-list-item-subtitle>{{ guia?.Bultos }}</v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title class="subtitle-2 font-weight-medium">
+                Remitos:
+              </v-list-item-title>
+              <v-list-item-subtitle>{{ guia?.Remitos }}</v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title class="subtitle-2 font-weight-medium">
+                Fecha Entrega:
+              </v-list-item-title>
+              <v-list-item-subtitle>{{ guia?.FechaEntrega }}</v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title class="subtitle-2 font-weight-medium">
+                Fecha Creación:
+              </v-list-item-title>
+              <v-list-item-subtitle>{{ guia?.FechaOriginal }}</v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title class="subtitle-2 font-weight-medium">
+                Estado:
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                <v-chip :class="getStatusChipClassTextual(guia?.Estado)" small>
+                  {{ guia?.Estado }}
+                </v-chip>
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+        <v-img v-if="fotoUrl" :src="fotoUrl" max-width="100%" class="mt-4" />
+      </v-card-text>
+      <v-divider />
+      <v-card-actions class="justify-end">
+        <v-btn color="primary" text @click="$emit('descargar', { guia, foto: fotoUrl })">Descargar PDF</v-btn>
+        <v-btn text color="primary" @click="$emit('close')">Cerrar</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import guias from '@/store/guias'
+
+export default {
+  name: 'GuiaEmpresaModal',
+  props: {
+    show: Boolean,
+    guia: Object,
+    getStatusChipClassTextual: Function
+  },
+  data() {
+    return { fotoUrl: null }
+  },
+  watch: {
+    show(val) {
+      if (val) this.fetchFoto()
+    },
+    guia() {
+      if (this.show) this.fetchFoto()
+    }
+  },
+  methods: {
+    async fetchFoto() {
+      this.fotoUrl = null
+      if (!this.guia) return
+      try {
+        const res = await guias.getFotosDocumentacionEntrega(this.guia.Id)
+        if (Array.isArray(res) && res.length > 0) {
+          const hash = res[0].Hash
+          this.fotoUrl = `https://a54-choferes-fotos-documentacion-entrega.s3.amazonaws.com/a54_cfde_${this.guia.Id}_${hash}`
+        }
+      } catch (e) {
+        console.error('Error cargando foto', e)
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/PanelSeguimientos/components/GuiasEmpresaTab.vue
+++ b/src/views/PanelSeguimientos/components/GuiasEmpresaTab.vue
@@ -1,0 +1,199 @@
+<template>
+  <v-card-text>
+    <v-toolbar flat dense class="header-menubar">
+      <v-toolbar-title class="subtitle-1 font-weight-medium">
+        Guías por Empresa
+      </v-toolbar-title>
+    </v-toolbar>
+
+    <div v-if="loading" class="text-center py-10">
+      <v-progress-circular indeterminate size="40" color="primary" />
+      <div class="mt-2">
+        <span class="body-2 text--secondary">
+          Cargando guías...
+        </span>
+      </div>
+    </div>
+
+    <div v-else-if="errorAlCargar" class="text-center py-10">
+      <v-icon size="36" color="error">mdi-alert-circle-outline</v-icon>
+      <div class="mt-2">
+        <span class="body-2 text--error">
+          {{ errorAlCargar }}
+        </span>
+      </div>
+    </div>
+
+    <div v-else-if="idEmpresa <= 0" class="text-center py-10">
+      <v-icon size="36" color="grey">mdi-office-building</v-icon>
+      <div class="mt-2">
+        <span class="body-2 text--secondary">
+          Seleccione una empresa para ver sus guías.
+        </span>
+      </div>
+    </div>
+
+    <div v-else>
+      <v-row align="center" justify="space-between" class="mb-4">
+        <v-col cols="12" md="6">
+          <v-text-field
+            v-model="localTextoBusqueda"
+            append-icon="mdi-magnify"
+            label="Buscar guías..."
+            dense
+            outlined
+            clearable
+          />
+        </v-col>
+
+        <v-col cols="12" md="3">
+          <v-select
+            v-model="localItemsPerPage"
+            :items="itemsPerPageOptions"
+            label="Filas por página"
+            dense
+            outlined
+            hide-details
+          />
+        </v-col>
+      </v-row>
+
+      <v-data-table
+        :headers="cabecerasGuiasEmpresa"
+        :items="guiasEmpresaFiltradasParaTabla"
+        :search="localTextoBusqueda"
+        item-key="Id"
+        :items-per-page="localItemsPerPage"
+        class="elevation-1"
+        dense
+        hide-default-footer
+        header-class="blue-header"
+      >
+        <template v-slot:item.Comprobante="{ item }">
+          <span class="body-2 font-weight-bold">
+            {{ item.Comprobante }}
+          </span>
+        </template>
+
+        <template v-slot:item.NombreDestino="{ item }">
+          <span class="body-2">{{ item.NombreDestino || 'N/A' }}</span>
+        </template>
+
+        <template v-slot:item.Bultos="{ item }">
+          <span class="body-2">{{ item.Bultos }}</span>
+        </template>
+
+        <template v-slot:item.Remitos="{ item }">
+          <span class="body-2">{{ item.Remitos || 'N/A' }}</span>
+        </template>
+
+        <template v-slot:item.FechaEntrega="{ item }">
+          <span class="body-2">{{ item.FechaEntrega }}</span>
+        </template>
+
+        <template v-slot:item.FechaOriginal="{ item }">
+          <span class="body-2">{{ item.FechaOriginal }}</span>
+        </template>
+
+        <template v-slot:item.Estado="{ item }">
+          <v-chip :class="getStatusChipClassTextual(item.Estado)" small>
+            {{ item.Estado }}
+          </v-chip>
+        </template>
+
+        <template v-slot:item.acciones="{ item }">
+          <v-btn
+            icon
+            small
+            @click="$emit('open-modal', item)"
+            :aria-label="`Ver detalles guía ${item.Comprobante}`"
+          >
+            <v-icon color="primary">mdi-eye-outline</v-icon>
+          </v-btn>
+        </template>
+
+        <template v-slot:footer.prepend>
+          <v-row align="center" justify="space-between" class="px-4">
+            <v-col cols="12" md="6">
+              <v-pagination
+                v-model="localPageGuias"
+                :length="pageCountGuiasEmpresa"
+                prev-icon="mdi-chevron-left"
+                next-icon="mdi-chevron-right"
+                circle
+                dense
+              />
+            </v-col>
+            <v-col cols="12" md="6" class="text-right">
+              <span class="caption text--secondary">
+                Mostrando {{ paginationInfoGuiasEmpresa }}
+              </span>
+            </v-col>
+          </v-row>
+        </template>
+
+        <template v-slot:no-data>
+          <v-alert type="warning" dense text>
+            No se encontraron guías para los filtros seleccionados.
+          </v-alert>
+        </template>
+      </v-data-table>
+    </div>
+  </v-card-text>
+</template>
+
+<script>
+export default {
+  name: 'GuiasEmpresaTab',
+  props: {
+    cabecerasGuiasEmpresa: Array,
+    guiasEmpresaFiltradasParaTabla: Array,
+    pageGuiasEmpresa: Number,
+    pageCountGuiasEmpresa: Number,
+    paginationInfoGuiasEmpresa: String,
+    itemsPerPageGuiasEmpresa: Number,
+    itemsPerPageOptions: Array,
+    textoBusquedaGuiasEmpresa: String,
+    idEmpresa: Number,
+    loading: Boolean,
+    errorAlCargar: [String, Object],
+    getStatusChipClassTextual: Function
+  },
+  data() {
+    return {
+      localPageGuias: this.pageGuiasEmpresa,
+      localItemsPerPage: this.itemsPerPageGuiasEmpresa,
+      localTextoBusqueda: this.textoBusquedaGuiasEmpresa
+    }
+  },
+  watch: {
+    localPageGuias(val) {
+      this.$emit('update:pageGuiasEmpresa', val)
+    },
+    pageGuiasEmpresa(val) {
+      this.localPageGuias = val
+    },
+    localItemsPerPage(val) {
+      this.$emit('update:itemsPerPageGuiasEmpresa', val)
+    },
+    itemsPerPageGuiasEmpresa(val) {
+      this.localItemsPerPage = val
+    },
+    localTextoBusqueda(val) {
+      this.$emit('update:textoBusquedaGuiasEmpresa', val)
+    },
+    textoBusquedaGuiasEmpresa(val) {
+      this.localTextoBusqueda = val
+    }
+  }
+}
+</script>
+
+<style scoped>
+.blue-header th {
+  background-color: var(--v-primary-base);
+  color: #fff;
+  font-weight: 600;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- create `GuiasEmpresaTab` table component
- add `GuiaEmpresaModal` for guide details and image
- integrate new tab in `Seguimientos.vue`
- load and filter company guide data
- enable PDF export with jsPDF

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f719c2dd8832aa6389f00930f3dc7