### PR TITLE
Fix modal photo fallback and filter delivered guides

### DIFF
--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -539,6 +539,11 @@ import jsPDF from 'jspdf'
 
         let filtrado = this.todasLasGuiasEmpresa
 
+        // Mostrar solo las guías entregadas
+        filtrado = filtrado.filter(
+          g => String(g.Estado).toUpperCase() === 'ENTREGADO'
+        )
+
         const fechaDesdeNormalized = this.normalizeDateToStartOfDay(this.fechaDesde)
         const fechaHastaNormalized = this.normalizeDateToStartOfDay(this.fechaHasta)
 

--- a/src/views/PanelSeguimientos/components/GuiaEmpresaModal.vue
+++ b/src/views/PanelSeguimientos/components/GuiaEmpresaModal.vue
@@ -72,6 +72,9 @@
           </v-list-item>
         </v-list>
         <v-img v-if="fotoUrl" :src="fotoUrl" max-width="100%" class="mt-4" />
+        <v-alert v-else type="info" dense text>
+          Aún no se cargó la foto de entrega
+        </v-alert>
       </v-card-text>
       <v-divider />
       <v-card-actions class="justify-end">


### PR DESCRIPTION
## Summary
- show an info alert when a guide has no delivery photo
- restrict `guiasEmpresaFiltradasParaTabla` to only returned delivered guides

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f82939bfc832aa06f6c995c2e006e