### PR TITLE
Adjust colors for VaciarPosicion and dark theme

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -41,12 +41,28 @@ html, body {
   background-color: #d8ecfa;
 }
 
+/* Dark theme row striping */
+.theme--dark .v-data-table tbody tr:nth-child(odd) {
+  background-color: #e1e1e2;
+}
+.theme--dark .v-data-table tbody tr:nth-child(even) {
+  background-color: #f7f5f5;
+}
+
 /* Row striping for plain tables */
 table tbody tr:nth-child(odd) {
   background-color: #f8f5f5;
 }
 table tbody tr:nth-child(even) {
   background-color: #d8ecfa;
+}
+
+/* Dark theme row striping */
+.theme--dark table tbody tr:nth-child(odd) {
+  background-color: #e1e1e2;
+}
+.theme--dark table tbody tr:nth-child(even) {
+  background-color: #f7f5f5;
 }
 /* Form headers color matches menu bar */
 .v-dialog .v-card-title,

--- a/src/views/VaciarPosicion.vue
+++ b/src/views/VaciarPosicion.vue
@@ -347,7 +347,7 @@ export default {
           datasets: [
             {
               data: [this.resumen.enUso, this.resumen.vacias],
-              backgroundColor: ["#43a047", "#ff5252"],
+              backgroundColor: ["#c9bae5", "#6d3b94"],
               borderColor: ["#fff", "#fff"],
               borderWidth: 3,
               hoverOffset: 16
@@ -584,15 +584,15 @@ export default {
   box-shadow: 0 14px 32px rgba(20, 30, 85, 0.16);
 }
 .tarjeta-resumen.azul {
-  background: linear-gradient(115deg,#417fff 65%,#6db2ff 98%);
+  background-color: #ef8194;
   color: #fff;
 }
 .tarjeta-resumen.verde {
-  background: linear-gradient(115deg,#5beb51 65%,#239a41 98%);
+  background-color: #c9bae5;
   color: #fff;
 }
 .tarjeta-resumen.rojo {
-  background: linear-gradient(115deg,#ff5252 65%,#b30021 98%);
+  background-color: #6d3b94;
   color: #fff;
 }
 .tarjeta-resumen .titulo {


### PR DESCRIPTION
## Summary
- tweak pie chart dataset colors for VaciarPosicion
- update resumen card colors for VaciarPosicion
- add dark theme row striping colors

## Testing
- `npm test` *(fails: start-server-and-test: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685046a89c80832a9533c08b2a877fa4