### PR TITLE
Override Vuetify active submenu weight

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -89,3 +89,8 @@ h6 {
 .capitalize-words {
   text-transform: capitalize;
 }
+
+/* Keep submenu titles normal even when active */
+.v-list-item--active .v-list-item-title {
+  font-weight: normal !important;
+}


### PR DESCRIPTION
## Summary
- keep submenu titles at normal font weight even when active

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504c8844f8832a9e95d07b9dbce1c5