### PR TITLE
Fix menu font weight

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -75,7 +75,7 @@ h6 {
 .v-list-item--active .v-list-item-title,
 .v-list-group--active > .v-list-group__items .v-list-item .v-list-item__title,
 .v-list-group--active > .v-list-group__items .v-list-item--active .v-list-item__title {
-  font-weight: 400 !important;
+  font-weight: 500 !important;
 }
 
 /* Match table headers with the menu bar color */


### PR DESCRIPTION
## Summary
- tweak active menu title font weight

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_685060caf044832a956b5540616f5520