### PR TITLE
Add search field styling

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -95,3 +95,5 @@ h6 {
   background-color: var(--v-menubar-base);
   color: #fff;
 }
+.search-field .v-input__slot { background-color: #f4fafe; color: #000; }
+.theme--dark .search-field .v-input__slot { background-color: #d9d9d9; color: #000; }

--- a/src/views/Empresas/ABMEmpresas.vue
+++ b/src/views/Empresas/ABMEmpresas.vue
@@ -7,7 +7,7 @@
         <v-row class="pb-0 mb-0">
             <v-col class="py-0 my-0" v-if="listaEmpresasCompleta.length>0" >
                 <v-card-title class="py-1 my-0">
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         label="Búsqueda"

--- a/src/views/Empresas/ConfiguracionMasiva.vue
+++ b/src/views/Empresas/ConfiguracionMasiva.vue
@@ -23,7 +23,7 @@
       <v-row justify="center" v-if="listaEmpresas.length>0">
         <v-col class="py-0 my-0"  >
           <v-card-title class="py-1 my-0">
-              <v-text-field
+              <v-text-field class="search-field"
                   v-model="textoBusqueda"
                   append-icon="mdi-magnify"
                   label="Búsqueda"

--- a/src/views/Guias/ActualizarFechas.vue
+++ b/src/views/Guias/ActualizarFechas.vue
@@ -14,7 +14,7 @@
     <v-row v-show="guias.length>0" class="pb-0 mb-0">
         <v-col class="py-0 my-0"  >
             <v-card-title class="py-1 my-0">
-                <v-text-field
+                <v-text-field class="search-field"
                     v-model="textoBusqueda"
                     append-icon="mdi-magnify"
                     label="Búsqueda"

--- a/src/views/Guias/GenerarDesdeOrdenes.vue
+++ b/src/views/Guias/GenerarDesdeOrdenes.vue
@@ -27,7 +27,7 @@
     <v-row v-if="ordenesFiltradas.length>0 && ordenesAProcesar.length==0" class="pb-0 mb-0">
         <v-col class="py-0 my-0"  >
             <v-card-title class="py-1 my-0">
-                <v-text-field
+                <v-text-field class="search-field"
                     v-model="textoBusqueda"
                     append-icon="mdi-magnify"
                     label="Búsqueda"

--- a/src/views/Guias/GenerarRendiciones.vue
+++ b/src/views/Guias/GenerarRendiciones.vue
@@ -35,7 +35,7 @@
     <v-row v-if="guiasARendirFiltradas.length>0" class="pb-0 mb-0">
       <v-col class="py-0 my-0"  >
         <v-card-title class="py-1 my-0">
-          <v-text-field
+          <v-text-field class="search-field"
               v-model="textoBusqueda"
               append-icon="mdi-magnify"
               label="Búsqueda"

--- a/src/views/Informes/GuiasPorPeriodo.vue
+++ b/src/views/Informes/GuiasPorPeriodo.vue
@@ -35,7 +35,7 @@
     <v-row v-show="informacionAExportar.length>0" class="pb-0 mb-0">
         <v-col class="py-0 my-0"  >
             <v-card-title class="py-1 my-0">
-                <v-text-field
+                <v-text-field class="search-field"
                     v-model="textoBusqueda"
                     append-icon="mdi-magnify"
                     label="Búsqueda"

--- a/src/views/Informes/OrdenesPorPeriodo.vue
+++ b/src/views/Informes/OrdenesPorPeriodo.vue
@@ -27,7 +27,7 @@
     <v-row v-show="informacionAExportar.length>0" class="pb-0 mb-0">
         <v-col class="py-0 my-0"  >
             <v-card-title class="py-1 my-0">
-                <v-text-field
+                <v-text-field class="search-field"
                     v-model="textoBusqueda"
                     append-icon="mdi-magnify"
                     label="Búsqueda"

--- a/src/views/Informes/Tracking.vue
+++ b/src/views/Informes/Tracking.vue
@@ -27,7 +27,7 @@
     <v-row v-show="informacionAExportar.length>0" class="pb-0 mb-0">
         <v-col class="py-0 my-0"  >
             <v-card-title class="py-1 my-0">
-                <v-text-field
+                <v-text-field class="search-field"
                     v-model="textoBusqueda"
                     append-icon="mdi-magnify"
                     label="Búsqueda"

--- a/src/views/ItinerarRuta.vue
+++ b/src/views/ItinerarRuta.vue
@@ -79,7 +79,7 @@
                         Entregas sin itinerar
                     </v-card-title>
                     <v-card-title class="py-1 my-0">
-                        <v-text-field
+                        <v-text-field class="search-field"
                             v-model="textoBusqueda"
                             append-icon="mdi-magnify"
                             label="Búsqueda"

--- a/src/views/Ordenes/CreacionManual.vue
+++ b/src/views/Ordenes/CreacionManual.vue
@@ -129,7 +129,7 @@
         <v-row v-show="items.length>0" class="pb-0 mb-0">
             <v-col class="py-0 my-0"  >
                 <v-card-title class="py-1 my-0">
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         label="Búsqueda"
@@ -229,7 +229,7 @@
                         <v-row v-if="listaArticulos.length>0" class="pb-0 mb-0">
                             <v-col class="py-0 my-0"  >
                                 <v-card-title class="py-1 my-0">
-                                    <v-text-field
+                                    <v-text-field class="search-field"
                                         v-model="textoBusqueda"
                                         append-icon="mdi-magnify"
                                         label="Búsqueda"
@@ -286,7 +286,7 @@
                         <v-row v-if="listaArticulos.length>0" class="pb-0 mb-0">
                             <v-col class="py-0 my-0"  >
                                 <v-card-title class="py-1 my-0">
-                                    <v-text-field
+                                    <v-text-field class="search-field"
                                         v-model="textoBusqueda"
                                         append-icon="mdi-magnify"
                                         label="Búsqueda"
@@ -320,7 +320,7 @@
                         <v-row v-if="listaArticulos.length>0" class="pb-0 mb-0">
                             <v-col class="py-0 my-0"  >
                                 <v-card-title class="py-1 my-0">
-                                    <v-text-field
+                                    <v-text-field class="search-field"
                                         v-model="textoBusqueda"
                                         append-icon="mdi-magnify"
                                         label="Búsqueda"

--- a/src/views/Ordenes/Ordenes.vue
+++ b/src/views/Ordenes/Ordenes.vue
@@ -13,7 +13,7 @@
       <v-row v-if="ordenes.length>0" class="pb-0 mb-0">
           <v-col class="py-0 my-0"  >
               <v-card-title class="py-1 my-0">
-                  <v-text-field
+                  <v-text-field class="search-field"
                       v-model="textoBusqueda"
                       append-icon="mdi-magnify"
                       label="Búsqueda"

--- a/src/views/Ordenes/OrdenesPendientes.vue
+++ b/src/views/Ordenes/OrdenesPendientes.vue
@@ -13,7 +13,7 @@
       <v-row v-if="ordenes.length>0" class="pb-0 mb-0">
           <v-col class="py-0 my-0"  >
               <v-card-title class="py-1 my-0">
-                  <v-text-field
+                  <v-text-field class="search-field"
                       v-model="textoBusqueda"
                       append-icon="mdi-magnify"
                       label="Búsqueda"

--- a/src/views/Posiciones/VerPosiciones.vue
+++ b/src/views/Posiciones/VerPosiciones.vue
@@ -22,7 +22,7 @@
     <v-row v-show="listaPosiciones.length>0" class="pb-0 mb-0" justify="center">
         <v-col cols="6" class="py-0 my-0"  >
           <v-card-title class="py-1 my-0">
-              <v-text-field
+              <v-text-field class="search-field"
                   v-model="textoBusqueda"
                   append-icon="mdi-magnify"
                   label="Búsqueda"

--- a/src/views/Productos/ABM.vue
+++ b/src/views/Productos/ABM.vue
@@ -29,7 +29,7 @@
         <v-row v-if="empresaElegida" class="pb-0 mb-0">
             <v-col class="py-0 my-0"  >
                 <v-card-title >
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         @keypress.enter = "buscarLote"

--- a/src/views/Seguridad/AsignarRoles.vue
+++ b/src/views/Seguridad/AsignarRoles.vue
@@ -5,7 +5,7 @@
         <v-row class="pb-0 mb-0">
             <v-col class="py-0 my-0" v-if="listaUsuariosCompleta.length>0" >
                 <v-card-title class="py-1 my-0">
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         label="Búsqueda"

--- a/src/views/Seguridad/Roles.vue
+++ b/src/views/Seguridad/Roles.vue
@@ -7,7 +7,7 @@
         <v-row class="pb-0 mb-0">
             <v-col class="py-0 my-0" v-if="listaRolesCompleta.length>0" >
                 <v-card-title class="py-1 my-0">
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         label="Búsqueda"

--- a/src/views/Seguridad/Usuarios.vue
+++ b/src/views/Seguridad/Usuarios.vue
@@ -7,7 +7,7 @@
         <v-row class="pb-0 mb-0">
             <v-col class="py-0 my-0" v-if="listaUsuariosCompleta.length>0" >
                 <v-card-title class="py-1 my-0">
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         label="Búsqueda"

--- a/src/views/Stock/Ajustes.vue
+++ b/src/views/Stock/Ajustes.vue
@@ -16,7 +16,7 @@
         <v-row v-show="listaArticulosMostrar.length>0" class="pb-0 mb-0">
             <v-col class="py-0 my-0"  >
                 <v-card-title class="py-1 my-0">
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         label="Búsqueda"
@@ -257,7 +257,7 @@
                        </v-col>
                 </v-row>
                     <v-card-title class="py-1 my-0">
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         label="Búsqueda"

--- a/src/views/Stock/Conciliacion.vue
+++ b/src/views/Stock/Conciliacion.vue
@@ -9,7 +9,7 @@
     <v-row v-show="articulos.length>0" class="pb-0 mb-0">
       <v-col class="py-0 my-0"  >
         <v-card-title class="py-1 my-0">
-          <v-text-field
+          <v-text-field class="search-field"
               v-model="textoBusqueda"
               append-icon="mdi-magnify"
               label="Búsqueda"

--- a/src/views/Stock/Stock.vue
+++ b/src/views/Stock/Stock.vue
@@ -75,7 +75,7 @@
         <v-row v-show="listaArticulosMostrar.length>0" class="pb-0 mb-0">
             <v-col class="py-0 my-0"  >
                 <v-card-title class="py-1 my-0">
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         label="Búsqueda"

--- a/src/views/Transportes/Choferes.vue
+++ b/src/views/Transportes/Choferes.vue
@@ -7,7 +7,7 @@
         <v-row class="pb-0 mb-0">
             <v-col class="py-0 my-0" v-if="listaChoferesCompleta.length>0" >
                 <v-card-title class="py-1 my-0">
-                    <v-text-field
+                    <v-text-field class="search-field"
                         v-model="textoBusqueda"
                         append-icon="mdi-magnify"
                         label="Búsqueda"

--- a/src/views/Transportes/RutaChoferes.vue
+++ b/src/views/Transportes/RutaChoferes.vue
@@ -42,7 +42,7 @@
     <v-row v-show="informacionAExportar.length>0" class="pb-0 mb-0">
         <v-col class="py-0 my-0"  >
             <v-card-title class="py-1 my-0">
-                <v-text-field
+                <v-text-field class="search-field"
                     v-model="textoBusqueda"
                     append-icon="mdi-magnify"
                     label="Búsqueda"


### PR DESCRIPTION
## Summary
- style search `<v-text-field>` elements with a reusable `.search-field` class
- update multiple views to use the new class
- tweak global styles for `.search-field`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506252e178832aadccbf5a345b6e66