### PR TITLE
Add action button style

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -97,3 +97,7 @@ h6 {
 }
 .search-field .v-input__slot { background-color: #f4fafe; color: #000; }
 .theme--dark .search-field .v-input__slot { background-color: #d9d9d9; color: #000; }
+
+/* Standardized button style for actions */
+.action-button { background-color: #b9c8ea; color: #191043; }
+.theme--dark .action-button { background-color: #d8ecfa; color: #212124; }

--- a/src/views/Empresas/ABMEmpresas.vue
+++ b/src/views/Empresas/ABMEmpresas.vue
@@ -2,7 +2,7 @@
     <v-container>
        <v-spacer></v-spacer>
         <v-row class="col-md">
-            <v-btn @click="createEmpresa()" color="success">Crear nueva empresa</v-btn>
+            <v-btn class="action-button" @click="createEmpresa()">Crear nueva empresa</v-btn>
         </v-row>
         <v-row class="pb-0 mb-0">
             <v-col class="py-0 my-0" v-if="listaEmpresasCompleta.length>0" >

--- a/src/views/Informes/GuiasPorPeriodo.vue
+++ b/src/views/Informes/GuiasPorPeriodo.vue
@@ -26,7 +26,7 @@
       </v-col>
     </v-row>
     <v-row justify="center" v-if="guiasSeleccionadas.length>0 && empresaLoggeada()<=0">
-      <v-col class="py-1" cols="12" sm="6" md="4"><v-btn @click="imprimirStickers()" color="success" block>Imprimir stickers<v-icon>mdi-sticker-text-outline</v-icon></v-btn></v-col>
+      <v-col class="py-1" cols="12" sm="6" md="4"><v-btn class="action-button" block @click="imprimirStickers()">Imprimir stickers<v-icon>mdi-sticker-text-outline</v-icon></v-btn></v-col>
       <v-col v-show="elegirEmpresa" class="py-1" cols="12" sm="6" md="4"><v-btn color="success" block @click="emitirFactura()">Emitir factura<v-icon>mdi-currency-usd</v-icon></v-btn></v-col>
     </v-row>
 

--- a/src/views/Ordenes/CreacionManual.vue
+++ b/src/views/Ordenes/CreacionManual.vue
@@ -211,7 +211,7 @@
             <v-col v-if="this.textil"><v-alert color="green" dark>Total Metros: {{totalM3}}</v-alert></v-col>
         </v-row>
         <v-row v-if="items.length>0">
-            <v-col><v-btn @click="crearOrden" block color="green" dark>Crear orden</v-btn></v-col>
+            <v-col><v-btn class="action-button" block @click="crearOrden">Crear orden</v-btn></v-col>
         </v-row>
 
         <v-dialog

--- a/src/views/Ordenes/Ordenes.vue
+++ b/src/views/Ordenes/Ordenes.vue
@@ -31,7 +31,7 @@
       </v-row>
       <v-row>
         <v-col v-if="ordenesSeleccionadas.length>0">
-          <v-btn @click="imprimirMasivo" color="blue" block dark>Imprimir ordenes seleccionadas en excel</v-btn>
+          <v-btn class="action-button" block @click="imprimirMasivo">Imprimir ordenes seleccionadas en excel</v-btn>
         </v-col>
       </v-row>
       <v-row>

--- a/src/views/Ordenes/OrdenesPendientes.vue
+++ b/src/views/Ordenes/OrdenesPendientes.vue
@@ -31,7 +31,7 @@
       </v-row>
       <v-row>
         <v-col v-if="ordenesSeleccionadas.length>0">
-          <v-btn @click="imprimirMasivo" color="blue" block dark>Imprimir ordenes seleccionadas en excel</v-btn>
+          <v-btn class="action-button" block @click="imprimirMasivo">Imprimir ordenes seleccionadas en excel</v-btn>
         </v-col>
       </v-row>
       <v-row>

--- a/src/views/Posiciones/VerPosiciones.vue
+++ b/src/views/Posiciones/VerPosiciones.vue
@@ -2,10 +2,10 @@
   <v-container>
     <v-row >
         <v-col align="end">
-            <v-btn color="blue" dark @click="crearPosicion()">Crear nueva posición</v-btn>
+            <v-btn class="action-button" @click="crearPosicion()">Crear nueva posición</v-btn>
           </v-col>
             <v-col >
-            <v-btn color="blue" dark @click="imprimirListaEtiquetas()">Imprimir lista etiquetas</v-btn>
+            <v-btn class="action-button" @click="imprimirListaEtiquetas()">Imprimir lista etiquetas</v-btn>
         </v-col>
     </v-row>
     <v-row justify="center" >

--- a/src/views/Productos/ABM Original Flex.vue
+++ b/src/views/Productos/ABM Original Flex.vue
@@ -27,7 +27,7 @@
                     <v-dialog v-model="mostrarEdicion" max-width="600px">
                         <template v-slot:activator="{on, attrs}">
                             <v-btn color="warning" dark class="mb-2 ml-1" @click="eliminarPosiciones()" >Eliminar posiciones</v-btn>
-                            <v-btn color="success" dark class="mb-2" v-bind="attrs" v-on="on">Crear posiciones</v-btn>
+                            <v-btn class="action-button mb-2" v-bind="attrs" v-on="on">Crear posiciones</v-btn>
                         </template>
                         <v-card>
                             <v-card-title ><span class="headline">Crear nuevas posiciones</span></v-card-title>

--- a/src/views/Productos/ABM.vue
+++ b/src/views/Productos/ABM.vue
@@ -43,7 +43,7 @@
         </v-row>
         <v-row v-if="empresaLoggeada()<=0 && idEmpresa>0"  > 
             <v-col class="col-sm-12 col-md-6">
-                <v-btn color="blue v-btn--block" v-if="!tieneLOTE" dark @click="crearArticulo()">Crear nuevo artículo</v-btn>
+                <v-btn class="action-button" v-if="!tieneLOTE" @click="crearArticulo()">Crear nuevo artículo</v-btn>
                 <v-btn color="blue v-btn--block" v-if="tieneLOTE" dark @click="popularListaProductos()">Cargar Lista</v-btn>
             </v-col>
             <v-col class="col-sm-12 col-md-6">

--- a/src/views/Seguridad/Roles.vue
+++ b/src/views/Seguridad/Roles.vue
@@ -2,7 +2,7 @@
     <v-container>
        <v-spacer></v-spacer>
         <v-row class="col-md">
-            <v-btn @click="createRoles()" color="success">Crear nuevo rol</v-btn>
+            <v-btn class="action-button" @click="createRoles()">Crear nuevo rol</v-btn>
         </v-row>
         <v-row class="pb-0 mb-0">
             <v-col class="py-0 my-0" v-if="listaRolesCompleta.length>0" >

--- a/src/views/Seguridad/Usuarios.vue
+++ b/src/views/Seguridad/Usuarios.vue
@@ -2,7 +2,7 @@
     <v-container>
        <v-spacer></v-spacer>
         <v-row v-show="listaUsuariosCompleta.length>0" class="col-md">
-            <v-btn @click="createUser()" color="success">Crear nuevo usuario</v-btn>
+            <v-btn class="action-button" @click="createUser()">Crear nuevo usuario</v-btn>
         </v-row>
         <v-row class="pb-0 mb-0">
             <v-col class="py-0 my-0" v-if="listaUsuariosCompleta.length>0" >

--- a/src/views/Transportes/Choferes.vue
+++ b/src/views/Transportes/Choferes.vue
@@ -2,7 +2,7 @@
     <v-container>
        <v-spacer></v-spacer>
         <v-row v-show="listaChoferesCompleta.length>0" class="col-md">
-            <v-btn @click="createChofer()" color="success">Crear nuevo chofer</v-btn>
+            <v-btn class="action-button" @click="createChofer()">Crear nuevo chofer</v-btn>
         </v-row>
         <v-row class="pb-0 mb-0">
             <v-col class="py-0 my-0" v-if="listaChoferesCompleta.length>0" >


### PR DESCRIPTION
## Summary
- add `.action-button` utility class
- unify various 'Crear...' and 'Imprimir...' buttons to use the new style

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_685063ab9e68832a9f4d451c8869eaed