### PR TITLE
Fix Material Design Icons font loading

### DIFF
--- a/public/fonts.css
+++ b/public/fonts.css
@@ -21,3 +21,12 @@
   font-style: normal;
   font-display: swap;
 }
+
+@font-face {
+  font-family: 'Material Design Icons';
+  src: url('fonts/materialdesignicons-webfont.woff2') format('woff2'),
+       url('fonts/materialdesignicons-webfont.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -8,8 +8,7 @@
     <title><%=process.env.VUE_APP_Nombre%></title>
     <!-- <title><%= htmlWebpackPlugin.options.title %></title> -->
     <link rel='stylesheet' href='<%= BASE_URL %>fonts.css'>
-    <!-- Carga de Material Design Icons -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@6.9.96/css/materialdesignicons.min.css">
+    <!-- Carga local de Material Design Icons -->
     <!-- Carga de FontAwesome -->
     <script src="https://kit.fontawesome.com/722592a0c4.js" crossorigin="anonymous"></script>
     <!-- Carga de Bootstrap -->

--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -190,8 +190,8 @@ h6 {
 /* Asegurar que los iconos de Material Design se muestren correctamente */
 @font-face {
   font-family: 'Material Design Icons';
-  src: url('https://cdn.jsdelivr.net/npm/@mdi/font@6.9.96/fonts/materialdesignicons-webfont.woff2') format('woff2'),
-       url('https://cdn.jsdelivr.net/npm/@mdi/font@6.9.96/fonts/materialdesignicons-webfont.woff') format('woff');
+  src: url('/fonts/materialdesignicons-webfont.woff2') format('woff2'),
+       url('/fonts/materialdesignicons-webfont.woff') format('woff');
   font-weight: normal;
   font-style: normal;
   font-display: block;

--- a/vue.config.js
+++ b/vue.config.js
@@ -20,6 +20,14 @@ module.exports = {
           {
             from: path.resolve(__dirname, 'node_modules/@fontsource/dm-sans/files/dm-sans-latin-700-normal.woff2'),
             to: path.resolve(__dirname, 'public/fonts/DMSans-Bold.woff2')
+          },
+          {
+            from: path.resolve(__dirname, 'node_modules/@mdi/font/fonts/materialdesignicons-webfont.woff2'),
+            to: path.resolve(__dirname, 'public/fonts/materialdesignicons-webfont.woff2')
+          },
+          {
+            from: path.resolve(__dirname, 'node_modules/@mdi/font/fonts/materialdesignicons-webfont.woff'),
+            to: path.resolve(__dirname, 'public/fonts/materialdesignicons-webfont.woff')
           }
         ]
       })


### PR DESCRIPTION
## Summary
- copy Material Design Icons fonts during build
- reference icon fonts locally instead of CDN
- update global CSS to point to local fonts

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c9066038832aa3ff3843b53f12d4