### PR TITLE
Apply rounded card styling

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -239,3 +239,15 @@ h6 {
 .v-btn .v-icon {
   font-family: 'Material Design Icons' !important;
 }
+
+/* Reusable rounded card style */
+.rounded-card {
+  border-radius: 12px;
+  background-color: var(--card-bg);
+}
+
+/* Optional rounded style for inputs */
+.rounded-input .v-input__slot,
+.rounded-input input {
+  border-radius: 8px;
+}

--- a/src/components/IngresoValorConfiguracion.vue
+++ b/src/components/IngresoValorConfiguracion.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <v-card>
+    <v-card class="rounded-card">
       <v-card-title class="py-0 my-2">
         {{titulo}}
       </v-card-title>

--- a/src/views/Empresas/ABMEmpresas.vue
+++ b/src/views/Empresas/ABMEmpresas.vue
@@ -47,7 +47,7 @@
          <!-- Dialog de Ajuste de Ingreso -->
          <v-row justify="center">
             <v-dialog v-model="empresaDialog" persistent max-width="600px">
-                <v-card>
+                <v-card class="rounded-card">
                     <v-card-title>
                         <span class="text-h5">Administración de empresa</span>
                     </v-card-title>

--- a/src/views/Informes/GuiasPorPeriodo.vue
+++ b/src/views/Informes/GuiasPorPeriodo.vue
@@ -73,7 +73,7 @@
       persistent
       max-width="600px"
     >
-      <v-card>
+      <v-card class="rounded-card">
         <v-card-title>
           <span class="text-h5">Guía: {{guiaEnEdicion.Id}}</span>
         </v-card-title>

--- a/src/views/Informes/Tracking.vue
+++ b/src/views/Informes/Tracking.vue
@@ -71,7 +71,7 @@
     </v-row>
     <v-row justify="center">
             <v-dialog v-model="seguimientoDialog" persistent max-width="1000px" >
-                <v-card>
+                <v-card class="rounded-card">
                     <v-card-title>
                       <v-row>
                         <v-col align="center">

--- a/src/views/Ordenes/CreacionManual.vue
+++ b/src/views/Ordenes/CreacionManual.vue
@@ -218,7 +218,7 @@
             v-model="mostrarListaArticulos"
             persistent
         >
-            <v-card v-show="!tieneLOTE">
+            <v-card v-show="!tieneLOTE" class="rounded-card">
                 <v-card-title>
                     <span class="text-h5">Productos</span>
                     <v-col> </v-col> <v-col> </v-col> <v-col> </v-col>
@@ -277,7 +277,7 @@
                     <v-btn color="blue darken-1" text @click="mostrarListaArticulos=false; textoBusqueda=''">Cerrar</v-btn>
                 </v-card-actions>
             </v-card>
-            <v-card v-show="tieneLOTE">
+            <v-card v-show="tieneLOTE" class="rounded-card">
                 <v-card-title>
                     <span class="text-h5">{{productosLote ? "Productos" : "Lote"}}</span>
                 </v-card-title>

--- a/src/views/PanelSeguimientos/components/GuiaEmpresaModal.vue
+++ b/src/views/PanelSeguimientos/components/GuiaEmpresaModal.vue
@@ -1,6 +1,6 @@
 <template>
   <v-dialog v-model="show" scrollable max-width="650px">
-    <v-card>
+    <v-card class="rounded-card">
       <v-card-title class="justify-space-between">
         <span class="text-h6">Detalle Conforme de entrega: {{ guia?.Comprobante }}</span>
         <v-btn icon @click="$emit('close')" aria-label="Cerrar detalle">

--- a/src/views/PanelSeguimientos/components/SeguimientoModal.vue
+++ b/src/views/PanelSeguimientos/components/SeguimientoModal.vue
@@ -1,6 +1,6 @@
 <template>
   <v-dialog v-model="show" scrollable max-width="650px">
-    <v-card>
+    <v-card class="rounded-card">
       <v-card-title class="justify-space-between">
         <span class="text-h6">
           Detalle de {{ modalType === 'orden' ? 'Orden' : 'Guía' }}: {{ modalData?.Numero || modalData?.Comprobante || '' }}

--- a/src/views/Posiciones/VerPosiciones.vue
+++ b/src/views/Posiciones/VerPosiciones.vue
@@ -53,7 +53,7 @@
     </v-row>
 
     <v-dialog v-model="mostrarVentanaEdicion" persistent max-width="800px">
-      <v-card>
+      <v-card class="rounded-card">
           <v-card-title>
               <span class="text-h5">Creación de nueva posición</span>
           </v-card-title>
@@ -77,7 +77,7 @@
     </v-dialog>
 
     <v-dialog v-model="mostrarDetallePosiciones" persistent max-width="1000px">
-      <v-card>
+      <v-card class="rounded-card">
           <v-card-title>
               <span class="text-h5">Contenido de la posición {{detallePosicionesPosicion}}</span>
           </v-card-title>
@@ -104,7 +104,7 @@
       </v-card>
     </v-dialog>
     <v-dialog v-model="mostrarResultadoCreacionMasiva" persistent max-width="1000px">
-      <v-card>
+      <v-card class="rounded-card">
           <v-card-title>
               <span class="text-h5">Proceso finalizado</span>
           </v-card-title>

--- a/src/views/Productos/ABM Original Flex.vue
+++ b/src/views/Productos/ABM Original Flex.vue
@@ -29,7 +29,7 @@
                             <v-btn color="warning" dark class="mb-2 ml-1" @click="eliminarPosiciones()" >Eliminar posiciones</v-btn>
                             <v-btn class="action-button mb-2" v-bind="attrs" v-on="on">Crear posiciones</v-btn>
                         </template>
-                        <v-card>
+                        <v-card class="rounded-card">
                             <v-card-title ><span class="headline">Crear nuevas posiciones</span></v-card-title>
                             <v-card-text  class="my-0 py-0">
                                 <v-container>

--- a/src/views/Productos/ABM.vue
+++ b/src/views/Productos/ABM.vue
@@ -93,7 +93,7 @@
             persistent
             max-width="800px"
         >
-        <v-card>
+        <v-card class="rounded-card">
             <v-card-title>
                 <span v-if="modoEdicion==='E'" class="text-h5">Producto: {{itemEnEdicion.Id}} - Barcode: {{itemEnEdicion.Barcode}}</span>
                 <span v-else class="text-h5">Creación de nuevo producto</span>
@@ -103,51 +103,51 @@
                     <v-container>
                         <v-row>
                             <v-col>
-                                <v-text-field :disabled="empresaLoggeada()>0" label="Nombre" :rules="[v => !!v || 'Requerido']" v-model="itemEnEdicion.Nombre"></v-text-field>
+                                <v-text-field class="rounded-input" :disabled="empresaLoggeada()>0" label="Nombre" :rules="[v => !!v || 'Requerido']" v-model="itemEnEdicion.Nombre"></v-text-field>
                             </v-col>
                             <v-col>
-                                <v-text-field :disabled="empresaLoggeada()>0" label="CodeEmpresa" :rules="[v => !!v || 'Requerido']" v-model="itemEnEdicion.CodeEmpresa"></v-text-field>
+                                <v-text-field class="rounded-input" :disabled="empresaLoggeada()>0" label="CodeEmpresa" :rules="[v => !!v || 'Requerido']" v-model="itemEnEdicion.CodeEmpresa"></v-text-field>
                             </v-col>
                             <v-col v-if="modoEdicion==='N'" >
-                                <v-text-field :disabled="empresaLoggeada()>0" label="Barcode" :rules="[v => !!v || 'Requerido']" v-model="itemEnEdicion.Barcode"></v-text-field>
+                                <v-text-field class="rounded-input" :disabled="empresaLoggeada()>0" label="Barcode" :rules="[v => !!v || 'Requerido']" v-model="itemEnEdicion.Barcode"></v-text-field>
                             </v-col>
                         </v-row>
                         <v-row v-if="!this.textil">
                             <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Ancho" required v-model="itemEnEdicion.Ancho"></v-text-field>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Ancho" required v-model="itemEnEdicion.Ancho"></v-text-field>
                             </v-col>
                             <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Alto" required v-model="itemEnEdicion.Alto"></v-text-field>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Alto" required v-model="itemEnEdicion.Alto"></v-text-field>
                             </v-col>
                         </v-row>
                         <v-row v-if="!this.textil">
                             <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Largo" required v-model="itemEnEdicion.Largo"></v-text-field>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Largo" required v-model="itemEnEdicion.Largo"></v-text-field>
                             </v-col>
                             <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Peso" required v-model="itemEnEdicion.Peso"></v-text-field>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Peso" required v-model="itemEnEdicion.Peso"></v-text-field>
                             </v-col>
                             <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Precio" required v-model="itemEnEdicion.Precio"></v-text-field>
-                            </v-col>
-                        </v-row>
-                        <v-row v-if="this.textil">
-                            <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Metros" required v-model="itemEnEdicion.Ancho"></v-text-field>
-                            </v-col>
-                            <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Alto" required v-model="itemEnEdicion.Alto"></v-text-field>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Precio" required v-model="itemEnEdicion.Precio"></v-text-field>
                             </v-col>
                         </v-row>
                         <v-row v-if="this.textil">
                             <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Ancho" required v-model="itemEnEdicion.Largo"></v-text-field>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Metros" required v-model="itemEnEdicion.Ancho"></v-text-field>
                             </v-col>
                             <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Peso" required v-model="itemEnEdicion.Peso"></v-text-field>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Alto" required v-model="itemEnEdicion.Alto"></v-text-field>
+                            </v-col>
+                        </v-row>
+                        <v-row v-if="this.textil">
+                            <v-col>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Ancho" required v-model="itemEnEdicion.Largo"></v-text-field>
                             </v-col>
                             <v-col>
-                                <v-text-field type="number" :disabled="empresaLoggeada()>0" label="Calidad" required v-model="itemEnEdicion.Precio"></v-text-field>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Peso" required v-model="itemEnEdicion.Peso"></v-text-field>
+                            </v-col>
+                            <v-col>
+                                <v-text-field class="rounded-input" type="number" :disabled="empresaLoggeada()>0" label="Calidad" required v-model="itemEnEdicion.Precio"></v-text-field>
                             </v-col>
                         </v-row>
                     </v-container>

--- a/src/views/Seguridad/AsignarRoles.vue
+++ b/src/views/Seguridad/AsignarRoles.vue
@@ -40,7 +40,7 @@
          <!-- Dialog  -->
          <v-row justify="center">
             <v-dialog v-model="rolDialog" persistent max-width="600px">
-                <v-card>
+                <v-card class="rounded-card">
                     <v-card-title>
                         <span class="text-h5">Asignacion de Roles por Usuario</span>
                     </v-card-title>

--- a/src/views/Seguridad/Roles.vue
+++ b/src/views/Seguridad/Roles.vue
@@ -42,7 +42,7 @@
          <!-- Dialog-->
          <v-row justify="center">
             <v-dialog v-model="rolDialog" persistent max-width="600px">
-                <v-card>
+                <v-card class="rounded-card">
                     <v-card-title>
                         <span class="text-h5">Administracion de Roles</span>
                     </v-card-title>

--- a/src/views/Seguridad/Usuarios.vue
+++ b/src/views/Seguridad/Usuarios.vue
@@ -47,7 +47,7 @@
          <!-- Dialog de Ajuste de Ingreso -->
          <v-row justify="center">
             <v-dialog v-model="usuarioDialog" persistent max-width="600px">
-                <v-card>
+                <v-card class="rounded-card">
                     <v-card-title>
                         <span class="text-h5">Administración de Usuario</span>
                     </v-card-title>

--- a/src/views/Stock/Ajustes.vue
+++ b/src/views/Stock/Ajustes.vue
@@ -78,7 +78,7 @@
         <!-- Dialog de Ajuste de Ingreso -->
         <v-row justify="center">
             <v-dialog v-model="AjusteIngresoDialog" persistent max-width="600px">
-                <v-card>
+                <v-card class="rounded-card">
                     <v-card-title>
                         <span class="text-h5">Registración de ingreso de stock</span>
                     </v-card-title>
@@ -152,7 +152,7 @@
         <!-- Dialog de Ajuste de Egreso -->
         <v-row justify="center">
             <v-dialog v-model="AjusteEgresoDialog" persistent max-width="600px">
-                <v-card>
+                <v-card class="rounded-card">
                     <v-card-title>
                         <span class="text-h5">Registración de egreso de stock</span>
                     </v-card-title>
@@ -226,7 +226,7 @@
         <!-- Dialog de Ajuste Masivo -->
         <v-row justify="center">
             <v-dialog v-model="AjusteMasivoDialog" persistent max-width="650px">
-               <v-card>
+               <v-card class="rounded-card">
                     <v-card-title >
                         <span class="text-h5">Ajuste Masivo</span>
                     </v-card-title>

--- a/src/views/Stock/Stock.vue
+++ b/src/views/Stock/Stock.vue
@@ -276,7 +276,7 @@
             persistent
             max-width="800px"
         >
-        <v-card>
+        <v-card class="rounded-card">
             <v-card-title>
                 <span class="text-h5">Producto: {{itemEnEdicion.Id}} - Barcode: {{itemEnEdicion.Barcode}}</span>
             </v-card-title>

--- a/src/views/Transportes/Choferes.vue
+++ b/src/views/Transportes/Choferes.vue
@@ -47,7 +47,7 @@
          <!-- Dialog de Ajuste de Ingreso -->
          <v-row justify="center">
             <v-dialog v-model="choferDialog" persistent max-width="600px">
-                <v-card>
+                <v-card class="rounded-card">
                     <v-card-title>
                         <span class="text-h5">Administración de Chofer</span>
                     </v-card-title>

--- a/src/views/Transportes/RutaChoferes.vue
+++ b/src/views/Transportes/RutaChoferes.vue
@@ -78,7 +78,7 @@
       persistent
       max-width="600px"
     >
-      <v-card>
+    <v-card class="rounded-card">
         <v-card-title>
           <span class="text-h5">Guía: {{guiaEnEdicion.Id}}</span>
         </v-card-title>

--- a/src/views/VaciarPosicion.vue
+++ b/src/views/VaciarPosicion.vue
@@ -173,7 +173,7 @@
 
       <!-- MODAL DETALLE DE ARTÍCULOS DE LA POSICIÓN -->
       <v-dialog v-model="showModal" max-width="900px">
-        <v-card>
+        <v-card class="rounded-card">
           <v-card-title class="text-h6">
             Productos en posición: <b>{{ posicionDetalle?.Nombre }}</b>
           </v-card-title>


### PR DESCRIPTION
## Summary
- add `.rounded-card` and `.rounded-input` classes
- apply the rounded card class on many form dialogs
- use `.rounded-input` for ABM product form fields

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ddb4b868832aae210826f2774732