### PR TITLE
Fix font path for Material Design icons

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -190,8 +190,8 @@ h6 {
 /* Asegurar que los iconos de Material Design se muestren correctamente */
 @font-face {
   font-family: 'Material Design Icons';
-  src: url('/fonts/materialdesignicons-webfont.woff2') format('woff2'),
-       url('/fonts/materialdesignicons-webfont.woff') format('woff');
+  src: url('../fonts/materialdesignicons-webfont.woff2') format('woff2'),
+       url('../fonts/materialdesignicons-webfont.woff') format('woff');
   font-weight: normal;
   font-style: normal;
   font-display: block;


### PR DESCRIPTION
## Summary
- adjust Material Design icon font URLs to be relative

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d90cb454832aa35213bb86d69d42