### PR TITLE
Add white form text color

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -151,6 +151,15 @@ table tbody tr:nth-child(3n) {
   background-color: var(--v-menubar-base);
   color: #fff;
 }
+
+/* Ensure form text contrasts with card backgrounds */
+.v-card .v-card-text {
+  color: #fff; /* same as menu bar text */
+}
+
+.theme--light .v-card .v-card-text {
+  color: #191043; /* dark text for light cards */
+}
 body,
 h1,
 h2,


### PR DESCRIPTION
## Summary
- ensure form text uses menu bar color
- override light theme text to maintain contrast

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850df0a52ac832ab905b34dea4971fc