### PR TITLE
Update dark theme table styles

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -163,6 +163,24 @@ table tbody tr:nth-child(3n) {
 .theme--dark table tbody tr:nth-child(3n) {
   background-color: var(--table-row-3-bg);
 }
+
+/* Texto oscuro y bordes para tablas en tema oscuro */
+.theme--dark .v-data-table td,
+.theme--dark table td {
+  color: #000000;
+  border-bottom: 1px solid #dbe1e5;
+}
+
+.theme--dark .v-data-table td:not(:last-child),
+.theme--dark table td:not(:last-child) {
+  border-right: 1px solid #dbe1e5;
+}
+
+.theme--dark .v-data-table,
+.theme--dark table {
+  border-radius: 8px;
+  overflow: hidden;
+}
 /* Form headers color matches menu bar */
 .v-dialog .v-card-title,
 .v-dialog .v-toolbar {

--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -81,7 +81,8 @@
   --stock-text: #f1fafd;  /* Color de texto para las tarjetas - Azul claro */            /* Color de texto para las tarjetas */
 
   /* Ajustes de tablas y formularios en oscuro */
-  --table-row-1-bg: #ffffff;
+  /* Colores intercalados para filas de tablas */
+  --table-row-1-bg: #f4fafe;
   --table-row-2-bg: #f7f5f5;
   --table-row-3-bg: #f4fafe;
   --search-field-bg: #d9d9d9;


### PR DESCRIPTION
## Summary
- tweak dark-mode table row colors
- ensure dark-theme tables use black text, light borders and rounded edges

## Testing
- `npm test` *(fails: start-server-and-test not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851078580b8832a97cd40abe80cad48