### PR TITLE
Adjust dark theme colors

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -200,12 +200,12 @@ table tbody tr:nth-child(3n) {
 .theme--dark .v-data-table td,
 .theme--dark table td {
   color: #000000;
-  border-bottom: 1px solid #dbe1e5;
+  border-bottom: 1px solid #56555a;
 }
 
 .theme--dark .v-data-table td:not(:last-child),
 .theme--dark table td:not(:last-child) {
-  border-right: 1px solid #dbe1e5;
+  border-right: 1px solid #56555a;
 }
 
 .v-data-table,
@@ -274,8 +274,8 @@ h6 {
   min-height: 44px;
 }
 .theme--dark .search-field .v-input__slot {
-  background-color: #232326 !important;
-  color: #f4fafe !important;
+  background-color: #d9d9d9 !important;
+  color: #212124 !important;
 }
 .theme--light .search-field .v-input__slot {
   background-color: #fff !important;
@@ -287,16 +287,23 @@ h6 {
 .theme--light .search-field input {
   color: #191043 !important;
 }
+.theme--dark .search-field input {
+  color: #212124 !important;
+}
 .search-field .v-input__prepend-outer,
 .search-field .v-input__append-inner {
   color: #f4fafe !important;
 }
-.theme--dark .search-field .v-input__slot { 
-  border-radius: 8px !important;
-  background-color: var(--v-background-surface) !important;
-  color: #fff !important;
+.theme--dark .search-field .v-input__prepend-outer,
+.theme--dark .search-field .v-input__append-inner {
+  color: #212124 !important;
 }
-.theme--light .search-field .v-input__slot { 
+.theme--dark .search-field .v-input__slot {
+  border-radius: 8px !important;
+  background-color: #d9d9d9 !important;
+  color: #212124 !important;
+}
+.theme--light .search-field .v-input__slot {
   border-radius: 8px !important;
   background-color: #fff !important;
   color: #191043 !important;

--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -86,8 +86,8 @@
   --table-row-2-bg: #f7f5f5;
   --table-row-3-bg: #f4fafe;
   --search-field-bg: #d9d9d9;
-  --action-button-bg: #d8ecfa;
-  --action-button-text: #212124;
+  --action-button-bg: #212124;
+  --action-button-text: #f1fafe;
 
   --login-bg: #2f2f2f;
   --login-card-bg: #232323;

--- a/src/views/Stock/Stock.vue
+++ b/src/views/Stock/Stock.vue
@@ -2162,7 +2162,7 @@ export default {
 
 .theme--dark .v-data-table td {
   color: rgba(255, 255, 255, 0.87) !important;
-  border-bottom-color: rgba(255, 255, 255, 0.12) !important;
+  border-bottom-color: #56555a !important;
 }
 
 /* Eliminar borde de la última fila */
@@ -2178,7 +2178,7 @@ export default {
 }
 
 .theme--dark .search-field.v-text-field--outlined {
-  background-color: #2D2D2D;
+  background-color: #d9d9d9;
 }
 
 .search-field .v-input__slot {
@@ -2194,7 +2194,7 @@ export default {
 }
 
 .theme--dark .search-field .v-input__slot input {
-  color: rgba(255, 255, 255, 0.87) !important;
+  color: #212124 !important;
 }
 
 /* Ajustar el color del label */
@@ -2204,7 +2204,7 @@ export default {
 }
 
 .theme--dark .search-field .v-label {
-  color: rgba(255, 255, 255, 0.7) !important;
+  color: #212124 !important;
 }
 
 /* Ajustar el color del borde */
@@ -2344,11 +2344,11 @@ export default {
 
 /* Ajustes para el tema oscuro */
 .theme--dark .search-field.v-text-field--outlined {
-  background-color: var(--v-menubar-base);
+  background-color: #d9d9d9;
 }
 
 .theme--dark .search-field .v-input__slot input {
-  color: #FFFFFF !important;
+  color: #212124 !important;
 }
 
 /* Asegurar que las celdas de la tabla tengan alineación vertical */
@@ -2466,21 +2466,21 @@ export default {
 
 /* Estilos para el campo de búsqueda en modo oscuro */
 .theme--dark .search-field.v-text-field .v-input__slot {
-  background-color: var(--v-menubar-base) !important;
-  color: #ffffff !important;
-  border: 1px solid rgba(255, 255, 255, 0.2) !important;
+  background-color: #d9d9d9 !important;
+  color: #212124 !important;
+  border: 1px solid rgba(33, 33, 36, 0.2) !important;
 }
 
 .theme--dark .search-field.v-text-field .v-label {
-  color: #f4fafe !important;
+  color: #212124 !important;
 }
 
 .theme--dark .search-field.v-text-field input {
-  color: #ffffff !important;
+  color: #212124 !important;
 }
 
 .theme--dark .search-field.v-text-field .v-icon {
-  color: #f4fafe !important;
+  color: #212124 !important;
 }
 
 /* Asegurar que el borde del campo sea consistente */


### PR DESCRIPTION
## Summary
- tune action button colors in dark mode
- update dark theme table borders
- restyle search fields for dark theme

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852349fe56c832ab25eac5b177470a6