### PR TITLE
Implement new light theme colors

### DIFF
--- a/docs/color-variables.md
+++ b/docs/color-variables.md
@@ -18,6 +18,7 @@ Este proyecto centraliza los colores en `src/assets/theme.css` para simplificar 
 | `--table-row-1-bg` | Colores alternados de filas en tablas. |
 | `--table-row-2-bg` | Id. |
 | `--table-row-3-bg` | Id. |
+| `--table-border-color` | Bordes internos de tablas. |
 | `--search-field-bg` | Campos de búsqueda. |
 | `--action-button-bg` | Botones de acción. |
 | `--action-button-text` | Texto de esos botones. |

--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -203,9 +203,19 @@ table tbody tr:nth-child(3n) {
   border-bottom: 1px solid #56555a;
 }
 
+.theme--light .v-data-table td,
+.theme--light table td {
+  border-bottom: 1px solid #56555a !important;
+}
+
 .theme--dark .v-data-table td:not(:last-child),
 .theme--dark table td:not(:last-child) {
   border-right: 1px solid #56555a;
+}
+
+.theme--light .v-data-table td:not(:last-child),
+.theme--light table td:not(:last-child) {
+  border-right: 1px solid #56555a !important;
 }
 
 .v-data-table,
@@ -278,14 +288,14 @@ h6 {
   color: #212124 !important;
 }
 .theme--light .search-field .v-input__slot {
-  background-color: #fff !important;
-  color: #191043 !important;
+  background-color: var(--search-field-bg) !important;
+  color: #56555a !important;
 }
 .search-field input {
   color: #f4fafe !important;
 }
 .theme--light .search-field input {
-  color: #191043 !important;
+  color: #56555a !important;
 }
 .theme--dark .search-field input {
   color: #212124 !important;
@@ -298,6 +308,10 @@ h6 {
 .theme--dark .search-field .v-input__append-inner {
   color: #212124 !important;
 }
+.theme--light .search-field .v-input__prepend-outer,
+.theme--light .search-field .v-input__append-inner {
+  color: #56555a !important;
+}
 .theme--dark .search-field .v-input__slot {
   border-radius: 8px !important;
   background-color: #d9d9d9 !important;
@@ -305,8 +319,8 @@ h6 {
 }
 .theme--light .search-field .v-input__slot {
   border-radius: 8px !important;
-  background-color: #fff !important;
-  color: #191043 !important;
+  background-color: var(--search-field-bg) !important;
+  color: #56555a !important;
 }
 
 /* Standardized button style for actions */

--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -16,7 +16,8 @@
   --table-row-1-bg: #ffffff;
   --table-row-2-bg: #f4fafe;
   --table-row-3-bg: #f7f5f5;
-  --search-field-bg: #f4fafe;
+  --search-field-bg: #ffffff;
+  --table-border-color: #56555a;
   --action-button-bg: #b9c8ea;
   --action-button-text: #191043;
   --slider-track-bg: #dbe1e5;


### PR DESCRIPTION
## Summary
- update color variable docs
- tweak search field colors for light theme
- add table border styles
- set new theme variables for search fields and table borders

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_685239e059bc832a825b959d880b0db0