### PR TITLE
Update search-field dark style

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -284,7 +284,7 @@ h6 {
   min-height: 44px;
 }
 .theme--dark .search-field .v-input__slot {
-  background-color: #d9d9d9 !important;
+  background-color: var(--search-field-bg) !important;
   color: #212124 !important;
 }
 .theme--light .search-field .v-input__slot {
@@ -314,7 +314,7 @@ h6 {
 }
 .theme--dark .search-field .v-input__slot {
   border-radius: 8px !important;
-  background-color: #d9d9d9 !important;
+  background-color: var(--search-field-bg) !important;
   color: #212124 !important;
 }
 .theme--light .search-field .v-input__slot {

--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -86,7 +86,7 @@
   --table-row-1-bg: #f4fafe;
   --table-row-2-bg: #f7f5f5;
   --table-row-3-bg: #f4fafe;
-  --search-field-bg: #d9d9d9;
+  --search-field-bg: #212124;
   --action-button-bg: #212124;
   --action-button-text: #ffffff;
 

--- a/src/views/Stock/Stock.vue
+++ b/src/views/Stock/Stock.vue
@@ -2178,7 +2178,7 @@ export default {
 }
 
 .theme--dark .search-field.v-text-field--outlined {
-  background-color: #d9d9d9;
+  background-color: var(--search-field-bg);
 }
 
 .search-field .v-input__slot {
@@ -2344,7 +2344,7 @@ export default {
 
 /* Ajustes para el tema oscuro */
 .theme--dark .search-field.v-text-field--outlined {
-  background-color: #d9d9d9;
+  background-color: var(--search-field-bg);
 }
 
 .theme--dark .search-field .v-input__slot input {
@@ -2466,7 +2466,7 @@ export default {
 
 /* Estilos para el campo de búsqueda en modo oscuro */
 .theme--dark .search-field.v-text-field .v-input__slot {
-  background-color: #d9d9d9 !important;
+  background-color: var(--search-field-bg) !important;
   color: #212124 !important;
   border: 1px solid rgba(33, 33, 36, 0.2) !important;
 }


### PR DESCRIPTION
## Summary
- centralize dark theme search-field color with `--search-field-bg`
- use the global variable in Stock search styles

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e0b1f920832ab9c59d7ba632f230