### PR TITLE
Update buttons to use action-button class

### DIFF
--- a/src/views/Stock/Ajustes.vue
+++ b/src/views/Stock/Ajustes.vue
@@ -11,7 +11,7 @@
             </v-col>           
         </v-row>
         <v-row v-show="listaArticulosMostrar.length>0" class="pb-0 mb-0">
-            <v-btn @click="ajusteMasivo(listaArticulosMostrar)" color="success">Generar Ingreso/Egreso Masivo</v-btn>
+            <v-btn @click="ajusteMasivo(listaArticulosMostrar)" class="action-button">Generar Ingreso/Egreso Masivo</v-btn>
         </v-row>
         <v-row v-show="listaArticulosMostrar.length>0" class="pb-0 mb-0">
             <v-col class="py-0 my-0"  >
@@ -128,14 +128,14 @@
                                 <v-card-actions>
                                 <v-spacer></v-spacer>
                                         <v-btn
-                                            color="blue darken-1"
+                                            class="action-button"
                                             text
                                             @click="resetValue('Ingreso')"
                                         >
                                             Cerrar
                                         </v-btn>
                                         <v-btn
-                                            color="blue darken-1"
+                                            class="action-button"
                                             text
                                             @click="updateStockProd(comprobante,unidades,'Ingreso')"
                                         >
@@ -202,14 +202,14 @@
                                 <v-card-actions>
                                 <v-spacer></v-spacer>
                                         <v-btn
-                                            color="blue darken-1"
+                                            class="action-button"
                                             text
                                             @click="resetValue('Egreso')"
                                         >
                                             Cerrar
                                         </v-btn>
                                         <v-btn
-                                            color="blue darken-1"
+                                            class="action-button"
                                             text
                                             @click="updateStockProd(comprobante,unidades,'Egreso')"
                                         >
@@ -326,14 +326,14 @@
                 <v-card-actions>
                      <v-spacer></v-spacer>
                                         <v-btn
-                                            color="blue darken-1"
+                                            class="action-button"
                                             text
                                             @click="resetValue('Ingreso')"
                                         >
                                             Cerrar
                                         </v-btn>
                                         <v-btn
-                                            color="blue darken-1"
+                                            class="action-button"
                                             text
                                             @click="validateAjusteMasivo()"
                                         >

--- a/src/views/VaciarPosicion.vue
+++ b/src/views/VaciarPosicion.vue
@@ -53,17 +53,16 @@
         </v-col>
         <v-col cols="12" md="8" class="d-flex align-end justify-end flex-wrap">
           <!-- Seleccionar todas las posiciones visibles -->
-          <v-btn class="boton-normalizado" @click="seleccionarTodas" small outlined :disabled="productosSeleccionadosGlobal.length > 0">
+          <v-btn class="boton-normalizado action-button" @click="seleccionarTodas" small outlined :disabled="productosSeleccionadosGlobal.length > 0">
             Seleccionar todas
           </v-btn>
           <!-- Exportar a Excel -->
-          <v-btn class="boton-normalizado mx-2" color="success" @click="exportarExcel" large>
+          <v-btn class="boton-normalizado mx-2 action-button" @click="exportarExcel" large>
             EXPORTAR A EXCEL <v-icon right>mdi-microsoft-excel</v-icon>
           </v-btn>
           <!-- Vaciar todas las posiciones seleccionadas -->
           <v-btn
-            class="boton-normalizado ml-2"
-            color="red"
+            class="boton-normalizado ml-2 action-button"
             :disabled="seleccionadas.length === 0 || productosSeleccionadosGlobal.length > 0"
             @click="vaciarSeleccionadas"
           >
@@ -149,8 +148,7 @@
             </v-list>
             <!-- Botón: Ejecutar desposicionamiento de todos los seleccionados -->
             <v-btn
-              color="red"
-              class="boton-normalizado mt-3"
+              class="boton-normalizado mt-3 action-button"
               :disabled="productosSeleccionadosGlobal.length === 0"
               @click="vaciarProductosSeleccionados"
               block
@@ -159,9 +157,8 @@
             </v-btn>
             <!-- Cancelar selección de productos -->
             <v-btn
-              class="boton-normalizado mt-3"
+              class="boton-normalizado mt-3 action-button"
               @click="limpiarSeleccionProductos"
-              color="grey"
               outlined
               block
             >
@@ -216,8 +213,7 @@
           <v-card-actions>
             <!-- Agregar a la selección global para desposicionar -->
             <v-btn
-              class="boton-normalizado"
-              color="blue"
+              class="boton-normalizado action-button"
               :disabled="productosSeleccionadosModal.length === 0"
               @click="agregarSeleccionadosGlobal"
             >


### PR DESCRIPTION
## Summary
- replace `color` attributes with `action-button` CSS class on VaciarPosicion and Ajustes pages
- update special buttons like *Seleccionar todas* and *Generar Ingreso/Egreso Masivo* to use the new class

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_685314307c4c832a9755729663d2040d