### PR TITLE
Add conditional menu display

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,11 @@
         @secundario="onDialogCancel"
       />
 
-      <MenuPrincipal :tituloPrincipal="TituloMenuPrincipal" class="py-0" />
+      <MenuPrincipal
+        v-if="isAuthenticated"
+        :tituloPrincipal="TituloMenuPrincipal"
+        class="py-0"
+      />
       <router-view />
     </v-main>
   </v-app>
@@ -50,6 +54,9 @@ export default {
     }),
     TituloMenuPrincipal() {
       return this.TituloPrincipal
+    },
+    isAuthenticated() {
+      return this.$store.state.usuarios.usuarioActual.Loggeado
     }
   },
   methods: {


### PR DESCRIPTION
## Summary
- show MenuPrincipal only when authenticated
- expose computed property `isAuthenticated`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853165a4ae8832a8954bdbb29dff16d