### PR TITLE
Fix logout redirection

### DIFF
--- a/src/store/usuarios.js
+++ b/src/store/usuarios.js
@@ -42,7 +42,7 @@ const usuarios = {
             sessionStorage.removeItem("usuarioNombre")
             sessionStorage.removeItem("usuarioId")
             sessionStorage.removeItem("idEmpresa")
-            router.push("/")
+            router.push("/Login")
         },
         async loginWithGoogle({ commit }, token) {
             store.dispatch('loading/mostrar', {titulo: 'Verificando con Google'})


### PR DESCRIPTION
## Summary
- redirect logout action to `/Login`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853170971e8832aaea9ca7f4e18129d