### PR TITLE
Add auditoria store module

### DIFF
--- a/src/store/auditoria.js
+++ b/src/store/auditoria.js
@@ -1,0 +1,61 @@
+import API from 'vue-lsi-util/APIAccesoV2'
+
+const auditoria = {
+  async getAuditoriaByEntidad(entidad) {
+    return new Promise((resolve, reject) => {
+      API.acceder({ Ruta: `/auditoria/getAuditoriaByEntidad/${entidad}` })
+        .then(data => resolve(data))
+        .catch(error => reject(error))
+    })
+  },
+
+  async getAuditoriaByEntidadId(entidad, id) {
+    return new Promise((resolve, reject) => {
+      API.acceder({ Ruta: `/auditoria/getAuditoriaByEntidadId/${entidad}/${id}` })
+        .then(data => resolve(data))
+        .catch(error => reject(error))
+    })
+  },
+
+  async getHistoricoOrden(idOrden) {
+    return new Promise((resolve, reject) => {
+      API.acceder({ Ruta: `/auditoria/getHistoricoOrden/${idOrden}` })
+        .then(data => resolve(data))
+        .catch(error => reject(error))
+    })
+  },
+
+  async getOrdenesEliminadas() {
+    return new Promise((resolve, reject) => {
+      API.acceder({ Ruta: '/auditoria/getOrdenesEliminadas' })
+        .then(data => resolve(data))
+        .catch(error => reject(error))
+    })
+  },
+
+  async getHistoricoGuia(idGuia) {
+    return new Promise((resolve, reject) => {
+      API.acceder({ Ruta: `/auditoria/getHistoricoGuia/${idGuia}` })
+        .then(data => resolve(data))
+        .catch(error => reject(error))
+    })
+  },
+
+  async getHistoricoPosiciones(idProducto, idEmpresa) {
+    return new Promise((resolve, reject) => {
+      API.acceder({ Ruta: `/auditoria/getHistoricoPosiciones/${idProducto}/${idEmpresa}` })
+        .then(data => resolve(data))
+        .catch(error => reject(error))
+    })
+  },
+
+  async getConfiguracionesByEmpresa(idEmpresa, fechaDesde, fechaHasta) {
+    return new Promise((resolve, reject) => {
+      API.acceder({ Ruta: `/auditoria/getConfiguracionesByEmpresa/${idEmpresa}/${fechaDesde}/${fechaHasta}` })
+        .then(data => resolve(data))
+        .catch(error => reject(error))
+    })
+  }
+}
+
+export default auditoria

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import axios from "axios";
 
 import usuarios from './usuarios'
 import empresas from './empresas'
+import auditoria from './auditoria'
 
 import snackbar from 'vue-lsi-util/snackbar'
 import loading from 'vue-lsi-util/loading'
@@ -18,7 +19,13 @@ axios.defaults.auth=JSON.parse(process.env.VUE_APP_API).Credenciales
 
 export default new Vuex.Store({
   modules: {
-    usuarios, empresas, snackbar, loading, alertDialog, sonidos
+    usuarios,
+    empresas,
+    auditoria,
+    snackbar,
+    loading,
+    alertDialog,
+    sonidos
 
   },
   state: {


### PR DESCRIPTION
## Summary
- add `auditoria` store module with API wrappers
- register new module in Vuex store

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542896d064832abfdc6393f3fd2e76