### PR TITLE
Fix logout menu not hidden

### DIFF
--- a/src/components/MenuPrincipal.vue
+++ b/src/components/MenuPrincipal.vue
@@ -525,7 +525,7 @@ export default {
     async cerrarSesion() {
       try {
         // Cerrar sesión en el store de Vuex
-        await store.dispatch('usuarios/cerrarSesion');
+        await store.dispatch('usuarios/desloggear');
         // Redirigir a la página de login
         this.$router.push('/login');
       } catch (error) {


### PR DESCRIPTION
## Summary
- fix dispatch call for logout using the actual `desloggear` action

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531e923a50832a9af9aa9fb0e22a5c