### PR TITLE
Add Auditoria menu e2e test

### DIFF
--- a/tests/e2e/specs/03-Auditoria.js
+++ b/tests/e2e/specs/03-Auditoria.js
@@ -1,0 +1,18 @@
+describe('Menú Seguridad', () => {
+    before(() => {
+        sessionStorage.removeItem("usuarioLoggeado")
+        sessionStorage.removeItem("usuarioNombre")
+        cy.visit('/')
+        cy.contains('Inicio de sesión')
+        cy.TipearLogin('Fer', 'Fer')
+        cy.get('[data-cy=IconoSesionIniciada]')
+    })
+
+    it('Debe mostrar Auditoría y navegar correctamente', () => {
+        cy.contains('SEGURIDAD').click()
+        cy.contains('Auditoría').should('exist')
+        cy.contains('Auditoría').click()
+        cy.url().should('include', '/Auditoria')
+    })
+})
+


### PR DESCRIPTION
## Summary
- add Cypress spec to ensure Auditoría menu works

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542992cb4c832a913c58eadc245f79