### PR TITLE
Update SelectorEmpresa validation

### DIFF
--- a/src/components/SelectorEmpresa.vue
+++ b/src/components/SelectorEmpresa.vue
@@ -3,8 +3,9 @@
         v-model="IdEmpresaSeleccionada"
         dense
         prepend-inner-icon="mdi-factory"
-        @change="eligioEmpresa"
         @keypress.enter="eligioEmpresa"
+        @blur="touched = true"
+        :rules="empresaRules"
         :chips="false"
         :items="listaEmpresas"
         item-value="Id"
@@ -26,7 +27,9 @@ export default {
     data() {
         return {
             IdEmpresaSeleccionada: null,
-            searchTerm: ''
+            searchTerm: '',
+            touched: false,
+            empresaRules: [v => !!v || 'Seleccione una empresa']
         }
     },
     props: {
@@ -37,9 +40,11 @@ export default {
             return this.$store.state.empresas.listaEmpresas
         }
     },
-    methods: {        
+    methods: {
         eligioEmpresa() {
-            this.$emit('eligioEmpresa', this.IdEmpresaSeleccionada)
+            if (this.IdEmpresaSeleccionada) {
+                this.$emit('eligioEmpresa', this.IdEmpresaSeleccionada)
+            }
         }
     },
     created() {


### PR DESCRIPTION
## Summary
- remove change listener from `SelectorEmpresa`
- add touched state and empresaRules for validation
- highlight required field on blur
- emit selection only when a valid empresa is chosen

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574f47abc8832a87dd1f5a62382a08