### PR TITLE
Add order history timeline

### DIFF
--- a/src/store/ordenesV3.js
+++ b/src/store/ordenesV3.js
@@ -202,7 +202,27 @@ const ordenesV3= {
         .then(response => {resolve(response)})
         .catch(puteada => {reject(puteada)})
       }
-    )            
+    )
+  },
+
+  async getHistoricoEstados(idOrden) {
+    return new Promise((resolve, reject) => {
+      API.acceder({
+        Metodo: "GET",
+        Ruta: `/ordenes/historico/${idOrden}`,
+        Cartel: "Obteniendo historial...",
+      })
+        .then((resp) => {
+          if (resp && Array.isArray(resp.data)) {
+            resolve(resp.data)
+          } else if (Array.isArray(resp)) {
+            resolve(resp)
+          } else {
+            resolve([])
+          }
+        })
+        .catch((err) => reject(err))
+    })
   },
 
   async getByNumeroAndIdEmpresa(numero, idEmpresa) {


### PR DESCRIPTION
## Summary
- add `getHistoricoEstados` to `ordenesV3` store
- load the historical states when opening an order modal
- compute current state from history and attach `historialEstados`
- build order timeline from `historialEstados`

## Testing
- `npm test --silent` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857651144ac832ab72fb31033ea0c1e