### PR TITLE
Handle raw order dates

### DIFF
--- a/src/mixins/seguimientosApiMixin.js
+++ b/src/mixins/seguimientosApiMixin.js
@@ -153,7 +153,9 @@ export default {
             console.error('historial orden error:', histErr)
             o.historialEstados = []
           }
-          o.Fecha = o.Fecha ? new Date(o.Fecha).toLocaleDateString('es-AR') : 'N/A'
+          o.FechaRaw = o.Fecha
+          o.FechaFormateada = o.Fecha ? new Date(o.Fecha).toLocaleDateString('es-AR') : 'N/A'
+          o.Fecha = o.FechaFormateada
           switch (o.Estado) {
             case 1: o.NombreEstado = 'Pendiente'; break
             case 2: o.NombreEstado = 'Preparado'; break
@@ -168,8 +170,8 @@ export default {
           o.IdGuia = o.IdGuia || -1
         }
         todasOrdenes.sort((a, b) => {
-          const dateA = new Date(a.Fecha.split('/').reverse().join('-'))
-          const dateB = new Date(b.Fecha.split('/').reverse().join('-'))
+          const dateA = new Date(a.FechaRaw)
+          const dateB = new Date(b.FechaRaw)
           return dateB.getTime() - dateA.getTime()
         })
         this.todasLasOrdenes = todasOrdenes
@@ -299,7 +301,9 @@ export default {
                 default: dataToModal.NombreEstado = `Desconocido (${dataToModal.Estado})`
               }
             }
-            dataToModal.Fecha = dataToModal.Fecha ? new Date(dataToModal.Fecha).toLocaleDateString('es-AR') : 'N/A'
+            if (!dataToModal.FechaFormateada && dataToModal.FechaRaw) {
+              dataToModal.FechaFormateada = new Date(dataToModal.FechaRaw).toLocaleDateString('es-AR')
+            }
             dataToModal.NombreEmpresa = dataToModal.NombreEmpresa || this.estaEmpresa.RazonSocial || 'N/A'
           } else {
             throw new Error('No se encontraron detalles válidos para esta orden.')

--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -765,8 +765,8 @@ import { construirTimelineOrden, construirTimelineGuia } from '@/helpers/timelin
           ]
           sheet.getRow(4).values = [
             'Fecha',
-            orden.Fecha
-              ? new Date(orden.Fecha).toLocaleDateString('es-AR')
+            orden.FechaRaw
+              ? new Date(orden.FechaRaw).toLocaleDateString('es-AR')
               : '',
           ]
           sheet.getRow(5).values = [
@@ -847,7 +847,7 @@ import { construirTimelineOrden, construirTimelineGuia } from '@/helpers/timelin
         sheet.getRow(3).values = ['Cliente', orden.NombreDestino || '']
         sheet.getRow(4).values = [
           'Fecha',
-          orden.Fecha ? new Date(orden.Fecha).toLocaleDateString('es-AR') : '',
+          orden.FechaRaw ? new Date(orden.FechaRaw).toLocaleDateString('es-AR') : '',
         ]
         sheet.getRow(5).values = ['Estado', orden.NombreEstado || orden.Estado || '']
 

--- a/src/views/PanelSeguimientos/components/OrdenesTab.vue
+++ b/src/views/PanelSeguimientos/components/OrdenesTab.vue
@@ -84,7 +84,7 @@
         </template>
 
         <template v-slot:item.Fecha="{ item }">
-          <span class="body-2">{{ item.Fecha ? new Date(item.Fecha).toLocaleDateString('es-AR') : 'N/A' }}</span>
+          <span class="body-2">{{ item.FechaFormateada || 'N/A' }}</span>
         </template>
 
         <template v-slot:item.Estado="{ item }">

--- a/src/views/PanelSeguimientos/components/SeguimientoModal.vue
+++ b/src/views/PanelSeguimientos/components/SeguimientoModal.vue
@@ -118,7 +118,7 @@
                       Fecha Creación:
                     </v-list-item-title>
                     <v-list-item-subtitle>
-                      {{ modalType === 'orden' ? (modalData.Fecha ? new Date(modalData.Fecha).toLocaleDateString('es-AR') : 'N/A') : modalData.FechaOriginal || 'N/A' }}
+                      {{ modalType === 'orden' ? (modalData.FechaFormateada || 'N/A') : modalData.FechaOriginal || 'N/A' }}
                     </v-list-item-subtitle>
                   </v-list-item-content>
                 </v-list-item>


### PR DESCRIPTION
## Summary
- keep original order date as `FechaRaw`
- store formatted date in `FechaFormateada`
- display formatted date in orders table and modal
- sort and export using `FechaRaw`

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68577e3741c4832a897f548e08e2bc69