### PR TITLE
Add remitos store module

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import axios from "axios";
 
 import usuarios from './usuarios'
 import empresas from './empresas'
+import remitos from './remitos'
 
 import snackbar from 'vue-lsi-util/snackbar'
 import loading from 'vue-lsi-util/loading'
@@ -18,7 +19,13 @@ axios.defaults.auth=JSON.parse(process.env.VUE_APP_API).Credenciales
 
 export default new Vuex.Store({
   modules: {
-    usuarios, empresas, snackbar, loading, alertDialog, sonidos
+    usuarios,
+    empresas,
+    remitos,
+    snackbar,
+    loading,
+    alertDialog,
+    sonidos
 
   },
   state: {

--- a/src/store/remitos.js
+++ b/src/store/remitos.js
@@ -1,0 +1,67 @@
+import API from 'vue-lsi-util/APIAccesoV2'
+
+const remitos = {
+  namespaced: true,
+  actions: {
+    async crearFromOrden(_, idOrden) {
+      return new Promise((resolve, reject) => {
+        API.acceder({
+          Ruta: `/remitos/fromOrden/${idOrden}`,
+          Metodo: 'POST',
+          Cartel: 'Generando remito...'
+        })
+        .then(data => resolve(data))
+        .catch(err => reject(err))
+      })
+    },
+
+    async getFromOrden(_, idOrden) {
+      return new Promise((resolve, reject) => {
+        API.acceder({ Ruta: `/remitos/fromOrden/${idOrden}` })
+          .then(data => resolve(data))
+          .catch(err => reject(err))
+      })
+    },
+
+    async getById(_, id) {
+      return new Promise((resolve, reject) => {
+        API.acceder({ Ruta: `/remitos/${id}` })
+          .then(data => resolve(data))
+          .catch(err => reject(err))
+      })
+    },
+
+    async getByOrden(_, idOrden) {
+      return new Promise((resolve, reject) => {
+        API.acceder({ Ruta: `/remitos/byOrden/${idOrden}` })
+          .then(data => resolve(data))
+          .catch(err => reject(err))
+      })
+    },
+
+    async getByEmpresa(_, { idEmpresa, desde = null, hasta = null }) {
+      return new Promise((resolve, reject) => {
+        let Ruta = `/remitos/byEmpresa/${idEmpresa}`
+        if (desde) {
+          Ruta += `/${desde}`
+          if (hasta) {
+            Ruta += `/${hasta}`
+          }
+        }
+        API.acceder({ Ruta })
+          .then(data => resolve(data))
+          .catch(err => reject(err))
+      })
+    },
+
+    async getHistorico(_, idRemito) {
+      return new Promise((resolve, reject) => {
+        API.acceder({ Ruta: `/remitos/historico/${idRemito}` })
+          .then(data => resolve(data))
+          .catch(err => reject(err))
+      })
+    }
+  }
+}
+
+export default remitos

--- a/src/views/Guias/VistaDeTracking.vue
+++ b/src/views/Guias/VistaDeTracking.vue
@@ -56,6 +56,7 @@
 import store from "../../store"
 import guias from "@/store/guias"
 
+
 export default {
     
     name: "VistaDeTracking",
@@ -159,7 +160,7 @@ export default {
         this.TokenAccesoTracking = item.TokenAccesoTracking
         this.Remitos= item.Remitos
         if(item.Remitos.includes('9999')){
-          this.remito = await guias.getRemitos(item.IdEmpresa,encodeURIComponent(item.Remitos.slice(-5)))    
+          this.remito = await store.dispatch('remitos/getById', encodeURIComponent(item.Remitos.slice(-5)))
           this.remito.forEach(r => {
             if(r.Remitos.includes('9991')){
               this.Reenvio = r.Remitos
@@ -167,7 +168,7 @@ export default {
             }
           })
         }else if(item.Remitos.includes('9991')){
-          this.remito = await guias.getRemitos(item.IdEmpresa,encodeURIComponent(item.Remitos))
+          this.remito = await store.dispatch('remitos/getById', encodeURIComponent(item.Remitos))
           this.remito.forEach(r => {
             if(r.Remitos.includes('9992')){
               this.Reenvio = r.Remitos
@@ -175,7 +176,7 @@ export default {
             }
           })
         }else{
-          this.remito = await guias.getRemitos(item.IdEmpresa,encodeURIComponent(item.Remitos))
+          this.remito = await store.dispatch('remitos/getById', encodeURIComponent(item.Remitos))
           this.remito.forEach(r => {
             if(r.Remitos.includes('9999')){
               this.Reenvio = r.Remitos

--- a/src/views/Informes/Tracking.vue
+++ b/src/views/Informes/Tracking.vue
@@ -317,7 +317,7 @@ export default {
 
       if(isNaN(item.Remitos != true)){
         if(item.Remitos.includes('9999')){
-          this.remito = await guias.getRemitos(item.IdEmpresa,item.Remitos.slice(-5))
+          this.remito = await store.dispatch('remitos/getById', item.Remitos.slice(-5))
           
           this.remito.forEach(r => {
             if(r.Remitos.includes('9991')){
@@ -326,7 +326,7 @@ export default {
             }
           })
         }else if(item.Remitos.includes('9991')){
-          this.remito = await guias.getRemitos(item.IdEmpresa,item.Remitos)
+          this.remito = await store.dispatch('remitos/getById', item.Remitos)
 
           this.remito.forEach(r => {
             if(r.Remitos.includes('9992')){
@@ -335,7 +335,7 @@ export default {
             }
         })
         } else {
-          this.remito = await guias.getRemitos(item.IdEmpresa,item.Remitos)
+          this.remito = await store.dispatch('remitos/getById', item.Remitos)
 
           this.remito.forEach(r => {
             if(r.Remitos.includes('9999')){


### PR DESCRIPTION
## Summary
- add Vuex module for remitos API endpoints
- register remitos module
- fetch remitos via new store actions in tracking views

## Testing
- `npm test` *(fails: start-server-and-test not found)*
- `npm install` *(fails: blocked download for Cypress)*

------
https://chatgpt.com/codex/tasks/task_e_685c3f7f6dc8832a85a2aab4ce70b7c6