### PR TITLE
Fix object property names in resetearPantalla

### DIFF
--- a/src/views/Ordenes/OrdenesSalida.vue
+++ b/src/views/Ordenes/OrdenesSalida.vue
@@ -638,14 +638,14 @@ async registrarProcesamientoOrden() {
             // comente esta linea porque al usar la lista de ordenes ya filtrada
             // para mostrarlas de nuevo sin tener que volver a cargar las ordenes, perdia el id de la empresa seleccionada
             //this.selectorEmpresa={mostrar: true, dato: null}
-            this.selectorOrden={mostrar: true, datos: null}
+            this.selectorOrden={mostrar: true, dato: null}
             if(this.tieneLOTE){
-                this.barcodeArticulo={mostrar: false, datos: null, lote: null}
+                this.barcodeArticulo={mostrar: false, dato: null, lote: null}
             } else {
-                this.barcodeArticulo={mostrar: false, datos: null}
+                this.barcodeArticulo={mostrar: false, dato: null}
             }
 
-            this.cantidadAIngresar={mostrar: false, datos: null}
+            this.cantidadAIngresar={mostrar: false, dato: null}
             this.listaProductosLeidos=[]
             this.cantidadBultos = 0
             this.pedirCantidadBultos=false


### PR DESCRIPTION
## Summary
- correct property names when resetting components in `OrdenesSalida.vue`

## Testing
- `npm install --silent` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68673aedbe84832abdc67934a6a04485