### PR TITLE
Fix extra comment in Seguimientos modal methods

### DIFF
--- a/src/views/PanelSeguimientos/Seguimientos.vue
+++ b/src/views/PanelSeguimientos/Seguimientos.vue
@@ -669,7 +669,6 @@ import { construirTimelineOrden, construirTimelineGuia } from '@/helpers/timelin
         this.errorAlCargar = null; // Limpia cualquier mensaje de error en el modal.
       },
   
-      /**
       openGuiaEmpresaModal(item) {
         this.guiaEmpresaModalData = item
         this.showGuiaEmpresaModal = true


### PR DESCRIPTION
## Summary
- remove stray comment before `openGuiaEmpresaModal`
- keep modal methods exported normally

## Testing
- `CYPRESS_INSTALL_BINARY=0 npm install`
- `CI=1 npm run build` *(failed: excessive output from Sass compiler)*

------
https://chatgpt.com/codex/tasks/task_e_686b3471b6b0832a96a8b681539ec0ee