### PR TITLE
Add email server/template stores

### DIFF
--- a/src/store/emailServers.js
+++ b/src/store/emailServers.js
@@ -1,0 +1,49 @@
+import API from 'vue-lsi-util/APIAccesoV2'
+
+const emailServers = {
+    async getOne(idEmpresa) {
+        return new Promise((resolve, reject) => {
+            API.acceder({ Ruta: `/emailServer/${idEmpresa}` })
+                .then(data => resolve(data))
+                .catch(err => reject(err))
+        })
+    },
+
+    async save(idEmpresa, payload) {
+        return new Promise((resolve, reject) => {
+            API.acceder({
+                Ruta: `/emailServer/${idEmpresa}`,
+                Metodo: 'PUT',
+                Body: payload,
+            })
+                .then(data => resolve(data))
+                .catch(err => reject(err))
+        })
+    },
+
+    async delete(idEmpresa) {
+        return new Promise((resolve, reject) => {
+            API.acceder({
+                Ruta: `/emailServer/${idEmpresa}`,
+                Metodo: 'DELETE',
+            })
+                .then(data => resolve(data))
+                .catch(err => reject(err))
+        })
+    },
+
+    async test(idEmpresa, body) {
+        return new Promise((resolve, reject) => {
+            API.acceder({
+                Ruta: `/emailServer/test/${idEmpresa}`,
+                Metodo: 'POST',
+                Body: body,
+            })
+                .then(data => resolve(data))
+                .catch(err => reject(err))
+        })
+    },
+}
+
+export default emailServers
+

--- a/src/store/emailTemplates.js
+++ b/src/store/emailTemplates.js
@@ -1,0 +1,49 @@
+import API from 'vue-lsi-util/APIAccesoV2'
+
+const emailTemplates = {
+    async getByCode(codigo) {
+        return new Promise((resolve, reject) => {
+            API.acceder({ Ruta: `/emailTemplate/byCode/${codigo}` })
+                .then(data => resolve(data))
+                .catch(err => reject(err))
+        })
+    },
+
+    async create(payload) {
+        return new Promise((resolve, reject) => {
+            API.acceder({
+                Ruta: `/emailTemplate`,
+                Metodo: 'PUT',
+                Body: payload,
+            })
+                .then(data => resolve(data))
+                .catch(err => reject(err))
+        })
+    },
+
+    async update(id, payload) {
+        return new Promise((resolve, reject) => {
+            API.acceder({
+                Ruta: `/emailTemplate/${id}`,
+                Metodo: 'PATCH',
+                Body: payload,
+            })
+                .then(data => resolve(data))
+                .catch(err => reject(err))
+        })
+    },
+
+    async activate(id, activo) {
+        return new Promise((resolve, reject) => {
+            API.acceder({
+                Ruta: `/emailTemplate/activate/${id}/${activo}`,
+                Metodo: 'PUT',
+            })
+                .then(data => resolve(data))
+                .catch(err => reject(err))
+        })
+    },
+}
+
+export default emailTemplates
+


### PR DESCRIPTION
## Summary
- add emailServers store module
- add emailTemplates store module

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889748c2e10832aba063eac9c7d7956