### PR TITLE
Add missing email config menu item

### DIFF
--- a/src/components/MenuPrincipal.vue
+++ b/src/components/MenuPrincipal.vue
@@ -480,6 +480,15 @@ export default {
           }
         }
 
+        const emailConfigExists = this.ListaDeMenusSeguridad.some(menu => menu.ruta === '/Seguridad/EmailConfig')
+        if (!emailConfigExists) {
+          this.ListaDeMenusSeguridad.push({
+            nombre: 'Configurar Correos',
+            ruta: '/Seguridad/EmailConfig',
+            modulo: 'seguridad'
+          })
+        }
+
         const todosGrupos = [
           { titulo: "STOCK", items: this.ListaDeMenusStock },
           { titulo: "ÓRDENES", items: this.ListaDeMenusOrdenes },


### PR DESCRIPTION
## Summary
- ensure security menu shows EmailConfig option if not returned by API

## Testing
- `npm install` *(fails: The Cypress app could not be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68898152c9b8832aa106507edc780fcb