### PR TITLE
Add EmailConfig Cypress spec

### DIFF
--- a/tests/e2e/specs/03-EmailConfig.js
+++ b/tests/e2e/specs/03-EmailConfig.js
@@ -1,0 +1,22 @@
+describe('EmailConfig page', () => {
+  beforeEach(() => {
+    sessionStorage.removeItem('usuarioLoggeado')
+    sessionStorage.removeItem('usuarioNombre')
+    cy.visit('/')
+    cy.TipearLogin('Fer', 'Fer')
+  })
+
+  it('should load and display form fields', () => {
+    cy.contains('button', 'SEGURIDAD').click()
+    cy.contains('div', 'Configurar Correos').click()
+
+    cy.url().should('include', '/Seguridad/EmailConfig')
+    cy.contains('label', 'Nombre')
+    cy.contains('label', 'Host')
+    cy.contains('label', 'Puerto')
+    cy.contains('label', 'Usuario')
+    cy.contains('label', 'Password')
+    cy.contains('label', 'Email Desde')
+    cy.contains('label', 'Nombre Desde')
+  })
+})


### PR DESCRIPTION
## Summary
- add e2e spec for the EmailConfig section

## Testing
- `npm run cy:run -- --spec tests/e2e/specs/03-EmailConfig.js` *(fails: `cypress: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688983663834832ab6f75baf0addae4f