### PR TITLE
Fix email templates loading

### DIFF
--- a/src/store/emailTemplates.js
+++ b/src/store/emailTemplates.js
@@ -10,6 +10,9 @@ const emailTemplates = {
                 Metodo: 'GET'
             })
             console.log('[emailTemplates] Plantillas obtenidas:', response)
+            if (Array.isArray(response)) {
+                return response
+            }
             return response.data || []
         } catch (error) {
             console.error('[emailTemplates] Error al obtener plantillas:', error)

--- a/src/views/Seguridad/EmailConfig.vue
+++ b/src/views/Seguridad/EmailConfig.vue
@@ -432,7 +432,7 @@ export default {
       try {
         this.loading = true
         const response = await emailTemplates.getAll()
-        this.templates = response.data || []
+        this.templates = response
       } catch (error) {
         console.error('Error al cargar plantillas:', error)
         this.$toast.error('Error al cargar las plantillas')


### PR DESCRIPTION
## Summary
- update `loadTemplates` to expect an array from API
- handle array response in `emailTemplates.getAll`

## Testing
- `npm test --silent` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_688af7f20f84832aaf6d2f4a013fac26