### PR TITLE
Implement getByEmpresa for email templates

### DIFF
--- a/src/store/emailTemplates.js
+++ b/src/store/emailTemplates.js
@@ -40,6 +40,25 @@ const emailTemplates = {
         }
     },
 
+    // Obtener plantillas por empresa
+    async getByEmpresa(idEmpresa) {
+        console.log(`[emailTemplates] Obteniendo plantillas para la empresa: ${idEmpresa}`)
+        try {
+            const response = await API.acceder({
+                Ruta: `/apiv3/emailTemplates/byEmpresa/${idEmpresa}`,
+                Metodo: 'GET'
+            })
+            console.log(`[emailTemplates] Plantillas de la empresa ${idEmpresa} obtenidas:`, response)
+            if (Array.isArray(response)) {
+                return response
+            }
+            return response.data || []
+        } catch (error) {
+            console.error(`[emailTemplates] Error al obtener plantillas para la empresa ${idEmpresa}:`, error)
+            throw error
+        }
+    },
+
     // Crear o actualizar plantilla
     async save(template) {
         const isUpdate = !!template.Id

--- a/src/views/Seguridad/EmailConfig.vue
+++ b/src/views/Seguridad/EmailConfig.vue
@@ -615,17 +615,11 @@ export default {
       
       // Cargar plantillas
       try {
-        // Verificar si el método getByCode existe antes de llamarlo
-        if (emailTemplates.getByCode && typeof emailTemplates.getByCode === 'function') {
-          console.log('Cargando plantillas para la empresa...')
-          console.time('getTemplates')
-          this.templates = await emailTemplates.getByCode(id)
-          console.timeEnd('getTemplates')
-          console.log('Plantillas cargadas:', this.templates)
-        } else {
-          console.warn('emailTemplates.getByCode no es una función, omitiendo carga de plantillas')
-          this.templates = []
-        }
+        console.log('Cargando plantillas para la empresa...')
+        console.time('getTemplates')
+        this.templates = await emailTemplates.getByEmpresa(id)
+        console.timeEnd('getTemplates')
+        console.log('Plantillas cargadas:', this.templates)
       } catch (error) {
         console.error('Error al cargar plantillas:', error)
         this.templates = []


### PR DESCRIPTION
## Summary
- add `getByEmpresa` method to emailTemplates store
- load templates by empresa in EmailConfig

## Testing
- `npm test --silent` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_688af96d75d4832a88d2d42cc09a2a5a