### PR TITLE
Implement backend image upload

### DIFF
--- a/src/helpers/uploadS3.js
+++ b/src/helpers/uploadS3.js
@@ -1,3 +1,6 @@
+// DEPRECATED: este helper se utilizaba para subir imágenes a AWS S3.
+// Las plantillas de correo ahora usan el endpoint /apiv3/emailTemplates/upload
+// para subir y servir imágenes desde el backend.
 const AWS = require('aws-sdk')
 import store from "../store"
 

--- a/src/store/emailTemplates.js
+++ b/src/store/emailTemplates.js
@@ -121,6 +121,27 @@ const emailTemplates = {
         }
     },
 
+    // Subir imagen y obtener URL
+    async uploadImage(file) {
+        console.log('[emailTemplates] Subiendo imagen:', file)
+        const formData = new FormData()
+        formData.append('image', file)
+
+        try {
+            const response = await API.acceder({
+                Ruta: '/apiv3/emailTemplates/upload',
+                Metodo: 'POST',
+                Body: formData
+            })
+            const url = response.url || (response.data && response.data.url)
+            console.log('[emailTemplates] Imagen subida. URL:', url)
+            return url
+        } catch (error) {
+            console.error('[emailTemplates] Error al subir imagen:', error)
+            throw error
+        }
+    },
+
     // Enviar correo de prueba
     async sendTestEmail(serverConfig, destinatario) {
         console.log('[emailTemplates] Enviando correo de prueba a:', destinatario)

--- a/src/views/Seguridad/EmailConfig.vue
+++ b/src/views/Seguridad/EmailConfig.vue
@@ -219,7 +219,6 @@
 import SelectorEmpresa from '@/components/SelectorEmpresa.vue'
 import emailServers from '@/store/emailServers'
 import emailTemplates from '@/store/emailTemplates'
-import { servicecAWS } from '@/helpers/uploadS3'
 import { quillEditor } from 'vue-quill-editor'
 import 'quill/dist/quill.snow.css'
 import { mapGetters } from 'vuex'
@@ -306,11 +305,9 @@ export default {
                 input.onchange = async function() {
                   const file = input.files[0];
                   if (!file) return;
-                  
-                  const nameFile = Date.now() + '_' + file.name;
+
                   try {
-                    await servicecAWS.uploadToS3(file, nameFile);
-                    const url = `https://s3.amazonaws.com/a54-choferes-fotos-documentacion-entrega/${nameFile}`;
+                    const url = await emailTemplates.uploadImage(file);
                     const quill = self.$refs.editor.quill;
                     const range = quill.getSelection(true);
                     quill.insertEmbed(range.index, 'image', url, 'user');


### PR DESCRIPTION
## Summary
- deprecate legacy S3 helper
- add `uploadImage` to emailTemplates store
- use new upload method from the Quill image handler

## Testing
- `npm test` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b6ed17258832a8a849a8ba99b7cbc