### PR TITLE
Move AWS credentials to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,16 @@ npm run serve
 Vue CLI will load `.env.development` automatically and API requests will be
 sent to `http://localhost:8128`.
 
+## AWS S3 uploads
+
+Some optional features upload files directly to Amazon S3. Provide your AWS
+credentials through environment variables in any `.env` file loaded by Vue CLI:
+
+```bash
+VUE_APP_AWS_ACCESS_KEY="YOUR_ACCESS_KEY"
+VUE_APP_AWS_SECRET="YOUR_SECRET_KEY"
+```
+
+The helper `src/helpers/uploadS3.js` reads these values via `process.env` when
+uploading files.
+

--- a/src/helpers/uploadS3.js
+++ b/src/helpers/uploadS3.js
@@ -12,8 +12,10 @@ async function uploadToS3(fileItem, nameFile) {
   console.group('Inicio cargado AWS',fileItem,nameFile)
 
 
-  const credentials = new AWS.Credentials('AKIA4UL5BS455UXSIPRO', '1reT5pqpYsi/3RmM2Zf++d8NHofWWTW6Q+zUjKQp')
-  //const credentials = new AWS.Credentials('AKIAQCQRB7JT2PCRY4SH', 'SQybrpqz8Xw+PbckbOe03nA+2nSYRElqAVgKhsgU')
+  const credentials = new AWS.Credentials(
+    process.env.VUE_APP_AWS_ACCESS_KEY,
+    process.env.VUE_APP_AWS_SECRET
+  )
 
   const S3 = new AWS.S3({credentials})
   console.log('Credential Ok !',)


### PR DESCRIPTION
## Summary
- get AWS credentials from `VUE_APP_AWS_ACCESS_KEY` and `VUE_APP_AWS_SECRET`
- document new environment variables

## Testing
- `npm test` *(fails: start-server-and-test not found)*
- `npm install` *(fails to download Cypress due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688b73296294832aa4a08a02be3ce084