### PR TITLE
Refactor email template routes

### DIFF
--- a/src/store/emailTemplates.js
+++ b/src/store/emailTemplates.js
@@ -39,7 +39,7 @@ const emailTemplates = {
         const start = Date.now();
         console.group(logPrefix);
         try {
-            const url = `/apiv3/emailTemplate/${tipo}`;
+            const url = `/emailTemplate/${tipo}`;
             console.log('🔍 Buscando plantilla...');
             const response = await API.acceder({ Ruta: url, Metodo: 'GET' });
             
@@ -112,7 +112,7 @@ const emailTemplates = {
         const logPrefix = `[emailTemplates] [${isUpdate ? 'update' : 'create'}]`;
         console.group(logPrefix);
         try {
-            const url = `/apiv3/emailTemplates${isUpdate ? `/${template.Id}` : ''}`;
+            const url = `/emailTemplates${isUpdate ? `/${template.Id}` : ''}`;
             const method = isUpdate ? 'PATCH' : 'POST';
             const requestData = {
                 Tipo: template.Tipo,
@@ -147,7 +147,7 @@ const emailTemplates = {
         console.log(log);
         const response = await API.acceder({
                 // PUT /emailTemplate/activate/:id/:activo
-                Ruta: `/apiv3/emailTemplates/activate/${id}/${activo}`,
+                Ruta: `/emailTemplates/activate/${id}/${activo}`,
             Metodo: 'PATCH'
         });
         return response?.data || response;
@@ -156,7 +156,7 @@ const emailTemplates = {
     async delete(id) {
         console.log(`[emailTemplates] [delete] Eliminando ${id}`);
         await API.acceder({
-                Ruta: `/apiv3/emailTemplates/${id}`,
+                Ruta: `/emailTemplates/${id}`,
             Metodo: 'DELETE'
         });
         return true;


### PR DESCRIPTION
## Summary
- remove hardcoded `/apiv3` prefix from email template store routes
- keep activation and delete endpoints consistent with new paths

## Testing
- `node --input-type=module test-emailTemplates.mjs` *(script in analysis verifying URLs; see console output)*
- `npm test` *(fails: build process lengthy/terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689026cedb84832ab945b525fa53c934